### PR TITLE
PR for JumpProblem, SSAStepper, and Jump types docstrings and doctests.

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,3 +1,5 @@
 [deps]
 DiffEqJump = "c894b116-72e5-5b58-be3c-e6d8d4ac2b12"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+StableRNGs = "860ef19b-820b-49d6-a774-d7a799459cd3"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -2,4 +2,4 @@
 DiffEqJump = "c894b116-72e5-5b58-be3c-e6d8d4ac2b12"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
-StableRNGs = "860ef19b-820b-49d6-a774-d7a799459cd3"
+StochasticDiffEq = "789caeaf-c7a9-5a7d-9973-96adeb23e2a0"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -5,11 +5,12 @@ include("pages.jl")
 makedocs(sitename = "DiffEqJump.jl",
          authors = "Chris Rackauckas",
          modules = [DiffEqJump],
-         clean = true, doctest = false,
+         clean = true, doctest = true,
          format = Documenter.HTML(analytics = "UA-90474609-3",
                                   assets = ["assets/favicon.ico"],
                                   canonical = "https://diffeqjump.sciml.ai/stable/"),
-         pages = pages)
+         pages = pages,
+         strict = false)
 
 deploydocs(repo = "github.com/SciML/DiffEqJump.jl.git";
            push_preview = true)

--- a/src/SSA_stepper.jl
+++ b/src/SSA_stepper.jl
@@ -11,28 +11,43 @@ Highly efficient integrator for pure jump problems that involve only
 
 ## Examples
 SIR model:
-```julia
+```jldoctest; output = false
 using DiffEqJump
 β = 0.1 / 1000.0; ν = .01;
 p = (β,ν)
-rate1(u,p,t) = p[1]*u[1]*u[2]  # β*S*I
+
+function rate1(u,p,t) 
+    p[1]*u[1]*u[2]  # β*S*I
+end
+
 function affect1!(integrator)
   integrator.u[1] -= 1         # S -> S - 1
   integrator.u[2] += 1         # I -> I + 1
 end
+
 jump = ConstantRateJump(rate1,affect1!)
 
-rate2(u,p,t) = p[2]*u[2]      # ν*I
+function rate2(u,p,t)
+    p[2]*u[2]      # ν*I
+end
+
 function affect2!(integrator)
   integrator.u[2] -= 1        # I -> I - 1
   integrator.u[3] += 1        # R -> R + 1
 end
+
 jump2 = ConstantRateJump(rate2,affect2!)
+
 u₀    = [999,1,0]
 tspan = (0.0,250.0)
 prob = DiscreteProblem(u₀, tspan, p)
 jump_prob = JumpProblem(prob, Direct(), jump, jump2)
 sol = solve(jump_prob, SSAStepper())
+
+sol isa ODESolution
+# output
+
+true
 ```
 see the
 [tutorial](https://diffeq.sciml.ai/stable/tutorials/discrete_stochastic_example/)

--- a/src/jumps.jl
+++ b/src/jumps.jl
@@ -150,8 +150,11 @@ rj isa RegularJump
 true
 ```
 
-Further, `RegularJump` problems require special solvers, such as
-`SimpleTauLeaping`. For example:
+!!! note
+
+    `RegularJump` problems require special solvers, such as `SimpleTauLeaping`.
+    
+## Example
 
 ```julia
 jumps = JumpSet(rj)


### PR DESCRIPTION
This PR updates the specific docstrings below. This is a first PR, to also confirm that the template and updates look good. Once everything looks good, I can continue to update the rest of the docstrings.  


Updated docstrings and docstests for JumpProblem, SSAStepper, MassActionJump,
ConstantRateJump, VariableRateJump, and RegularJump. Also added
`strict` doctest checks in make.jl. Added StableRNGs, and LinearAlgebra to
Project.toml for docs, as a necessary requirement for some doctests.