### PR TITLE
Ficticious jump algorithm for time-dependent variable rate jumps.

### DIFF
--- a/src/JumpProcesses.jl
+++ b/src/JumpProcesses.jl
@@ -49,6 +49,7 @@ include("aggregators/prioritytable.jl")
 include("aggregators/directcr.jl")
 include("aggregators/rssacr.jl")
 include("aggregators/rdirect.jl")
+include("aggregators/extrande.jl")
 
 # spatial:
 include("spatial/spatial_massaction_jump.jl")
@@ -82,6 +83,7 @@ export Direct, DirectFW, SortingDirect, DirectCR
 export BracketData, RSSA
 export FRM, FRMFW, NRM
 export RSSACR, RDirect
+export Extrande
 
 export get_num_majumps, needs_depgraph, needs_vartojumps_map
 

--- a/src/aggregators/aggregators.jl
+++ b/src/aggregators/aggregators.jl
@@ -144,8 +144,18 @@ doi: 10.1063/1.4928635
 """
 struct DirectCRDirect <: AbstractAggregatorAlgorithm end
 
+"""
+The Extrande method for simulating variable rate jumps with user-defined bounds
+on jumps rates and validity intervals via rejection.
+
+Stochastic Simulation of Biomolecular Networks in Dynamic Environments, Voliotis
+M, Thomas P, Grima R, Bowsher CG, PLOS Computational Biology 12(6): e1004923.
+(2016); doi.org/10.1371/journal.pcbi.1004923
+"""
+struct Extrande <: AbstractAggregatorAlgorithm end
+
 const JUMP_AGGREGATORS = (Direct(), DirectFW(), DirectCR(), SortingDirect(), RSSA(), FRM(),
-                          FRMFW(), NRM(), RSSACR(), RDirect())
+                          FRMFW(), NRM(), RSSACR(), RDirect(), Extrande())
 
 # For JumpProblem construction without an aggregator
 struct NullAggregator <: AbstractAggregatorAlgorithm end
@@ -167,3 +177,6 @@ needs_vartojumps_map(aggregator::RSSACR) = true
 is_spatial(aggregator::AbstractAggregatorAlgorithm) = false
 is_spatial(aggregator::NSM) = true
 is_spatial(aggregator::DirectCRDirect) = true
+
+is_ficticious(aggregator::AbstractAggregatorAlgorithm) = false
+is_ficticious(aggregator::Extrande) = true

--- a/src/aggregators/extrande.jl
+++ b/src/aggregators/extrande.jl
@@ -1,0 +1,133 @@
+# Define the aggregator. 
+struct Extrande <: AbstractAggregatorAlgorithm end
+
+"""
+Extrande sampling method for jumps with defined rate bounds.
+"""
+
+nullaffect!(integrator) = nothing
+const NullAffectJump = ConstantRateJump((u,p,t) -> 0.0, nullaffect!)
+
+mutable struct ExtrandeJumpAggregation{T,S,F1,F2,F3,F4,RNG} <: AbstractSSAJumpAggregator
+    next_jump::Int
+    prev_jump::Int
+    next_jump_time::T
+    end_time::T
+    cur_rates::Vector{T}
+    sum_rate::T
+    ma_jumps::S
+    rate_bnds::F3
+    wds::F4
+    rates::F1
+    affects!::F2
+    save_positions::Tuple{Bool,Bool}
+    rng::RNG
+end
+
+function ExtrandeJumpAggregation(nj::Int, njt::T, et::T, crs::Vector{T}, sr::T, maj::S, rs::F1, affs!::F2, sps::Tuple{Bool,Bool}, rng::RNG; rate_bounds::F3, windows::F4, kwargs...) where {T,S,F1,F2,F3,F4,RNG}
+
+    ExtrandeJumpAggregation{T,S,F1,F2,F3,F4,RNG}(nj, nj, njt, et, crs, sr, maj, rate_bounds, windows, rs, affs!, sps, rng)
+end
+
+
+############################# Required Functions ##############################
+function aggregate(aggregator::Extrande, u, p, t, end_time, constant_jumps,
+                   ma_jumps, save_positions, rng; bounded_va_jumps, kwargs...)
+
+    rates, affects! = get_jump_info_fwrappers(u, p, t, (constant_jumps..., bounded_va_jumps..., NullAffectJump))
+    rbnds, wnds = get_va_jump_bound_info_fwrapper(u, p, t, (constant_jumps..., bounded_va_jumps...,NullAffectJump))
+    build_jump_aggregation(ExtrandeJumpAggregation, u, p, t, end_time, ma_jumps,
+                           rates, affects!, save_positions, rng; u=u, rate_bounds=rbnds, windows=wnds, kwargs...)
+end
+
+# set up a new simulation and calculate the first jump / jump time
+function initialize!(p::ExtrandeJumpAggregation, integrator, u, params, t)
+    p.end_time = integrator.sol.prob.tspan[2]
+    generate_jumps!(p, integrator, u, params, t)
+end
+
+# execute one jump, changing the system state
+@inline function execute_jumps!(p::ExtrandeJumpAggregation, integrator, u, params, t)
+    # execute jump
+    u = update_state!(p, integrator, u)
+    nothing
+end
+
+@fastmath function next_ma_jump(p::ExtrandeJumpAggregation, u, params, t)
+    ttnj      = typemax(typeof(t))
+    nextrx    = zero(Int)
+    majumps   = p.ma_jumps
+    @inbounds for i in 1:get_num_majumps(majumps)
+        p.cur_rates[i] = evalrxrate(u, i, majumps)
+        dt = randexp(p.rng) / p.cur_rates[i]
+        if dt < ttnj
+            ttnj   = dt
+            nextrx = i
+        end
+    end
+    nextrx, ttnj
+end
+
+@fastmath function next_extrande_jump(p::ExtrandeJumpAggregation, u, params, t) 
+    ttnj   = typemax(typeof(t))
+    nextrx = zero(Int)
+    Wmin = typemax(typeof(t))
+    Bmax = typemax(typeof(t)) 
+
+    # Calculate the total rate bound and the largest common validity window.
+    Ws = zeros(typeof(t), length(p.wds))
+    Bs = zeros(typeof(t), length(p.rate_bnds))
+    if !isempty(p.rate_bnds)
+        idx = get_num_majumps(p.ma_jumps) + 1
+        @inbounds for i in 1:length(p.wds)
+            Ws[i] = p.wds[i](u,params,t) 
+            Bs[i] = p.rate_bnds[i](u,params,t) 
+        end
+        Wmin = minimum(Ws)
+        Bmax = sum(Bs) 
+    end
+    
+    # Rejection sampling.
+    if !isempty(p.rates)
+        nextrx = length(p.rates)
+        idx = get_num_majumps(p.ma_jumps) + 1
+        prop_ttnj = randexp(p.rng) / Bmax
+        if prop_ttnj < t + Wmin
+            fill_cur_rates(u, params, t, p.cur_rates, idx, p.rates...)
+
+            prev_rate = zero(t)
+            cur_rates = p.cur_rates
+            @inbounds for i in idx:length(cur_rates)
+              cur_rates[i] = cur_rates[i] + prev_rate
+              prev_rate    = cur_rates[i]
+            end
+
+            UBmax = rand(p.rng) * Bmax
+            ttnj = prop_ttnj
+            if  p.cur_rates[end] ≥ UBmax 
+                @inbounds nextrx = findfirst(x -> x ≥ UBmax, p.cur_rates) 
+            end
+        else 
+            ttnj = Wmin
+        end
+    end
+
+    return nextrx, ttnj
+end
+
+
+function generate_jumps!(p::ExtrandeJumpAggregation, integrator, u, params, t)
+    nextmaj, ttnmaj = next_ma_jump(p, u, params, t)
+    nextexj, ttnexj = next_extrande_jump(p, u, params, t)
+    
+    # execute reaction with minimal time
+    if ttnmaj < ttnexj
+      p.next_jump      = nextmaj
+      p.next_jump_time = t + ttnmaj
+    else
+      p.next_jump      = nextexj
+      p.next_jump_time = t + ttnexj
+    end
+
+    nothing
+end

--- a/test/extrande.jl
+++ b/test/extrande.jl
@@ -1,0 +1,20 @@
+using DiffEqBase, JumpProcesses, OrdinaryDiffEq, Test
+using StableRNGs
+rng = StableRNG(12345)
+
+rate = (u,p,t) -> t
+affect! = (integrator) -> (integrator.u[1] = integrator.u[1]+1)
+rbound = (u,p,t) -> (t + 0.1)
+rwindow = (u,p,t) -> 0.1
+jump = VariableRateJump(rate,affect!,interp_points=1000,rbnd=rbound,rwnd=rwindow)
+jump2 = deepcopy(jump)
+
+f = function (du,u,p,t)
+  du[1] = 0.0 
+end
+
+prob = ODEProblem(f,[0.0],(0.0,10.0))
+jump_prob = JumpProblem(prob,Extrande(),jump; rng=rng)
+
+integrator = init(jump_prob,Tsit5())
+sol = solve(jump_prob,Tsit5())

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -25,4 +25,5 @@ using JumpProcesses, DiffEqBase, SafeTestsets
     @time @safetestset "Spatial A + B <--> C" begin include("spatial/ABC.jl") end
     @time @safetestset "Spatially Varying Reaction Rates" begin include("spatial/spatial_majump.jl") end
     @time @safetestset "Pure diffusion" begin include("spatial/diffusion.jl") end
+    @time @safetestset "Ficticious Jump " begin include("extrande.jl") end
 end


### PR DESCRIPTION
Extends the VariableRateJump interface to allow for user-defined bounds on time-dependent jump rates and look-ahead horizons for which the bound is valid. Implements a fictitious jump rejection algorithm based on [https://journals.plos.org/ploscompbiol/article?id=10.1371/journal.pcbi.1004923](https://journals.plos.org/ploscompbiol/article?id=10.1371/journal.pcbi.1004923).

Relevant issue: [https://github.com/SciML/JumpProcesses.jl/issues/28](https://github.com/SciML/JumpProcesses.jl/issues/28)