### PR TITLE
Remove CartesianGridIter.

### DIFF
--- a/src/JumpProcesses.jl
+++ b/src/JumpProcesses.jl
@@ -92,7 +92,7 @@ export reset_aggregated_jumps!
 export ExtendedJumpArray
 
 # spatial structs and functions
-export CartesianGrid, CartesianGridRej, CartesianGridIter
+export CartesianGrid, CartesianGridRej
 export SpatialMassActionJump
 export outdegree, num_sites, neighbors
 export NSM, DirectCRDirect

--- a/src/spatial/hop_rates.jl
+++ b/src/spatial/hop_rates.jl
@@ -14,7 +14,7 @@ function HopRates(hopping_constants::Vector{F}, spatial_system) where {F <: Numb
     HopRatesGraphDs(hopping_constants, num_sites(spatial_system))
 end
 function HopRates(hopping_constants::Vector{F},
-                  grid::Union{CartesianGridRej, CartesianGridIter}) where {F <: Number}
+                  grid::CartesianGridRej) where {F <: Number}
     HopRatesGraphDs(hopping_constants, num_sites(grid))
 end
 
@@ -22,7 +22,7 @@ function HopRates(hopping_constants::Matrix{F}, spatial_system) where {F <: Numb
     HopRatesGraphDsi(hopping_constants)
 end
 function HopRates(hopping_constants::Matrix{F},
-                  grid::Union{CartesianGridRej, CartesianGridIter}) where {F <: Number}
+                  grid::CartesianGridRej) where {F <: Number}
     HopRatesGraphDsi(hopping_constants)
 end
 
@@ -30,7 +30,7 @@ function HopRates(hopping_constants::Matrix{Vector{F}}, spatial_system) where {F
     HopRatesGraphDsij(hopping_constants)
 end
 function HopRates(hopping_constants::Matrix{Vector{F}},
-                  grid::Union{CartesianGridRej, CartesianGridIter}) where {F <: Number}
+                  grid::CartesianGridRej) where {F <: Number}
     HopRatesGridDsij(hopping_constants, grid)
 end
 
@@ -40,7 +40,7 @@ function HopRates(p::Pair{SpecHop, SiteHop},
     HopRatesGraphDsLij(p...)
 end
 function HopRates(p::Pair{SpecHop, SiteHop},
-                  grid::Union{CartesianGridRej, CartesianGridIter}) where
+                  grid::CartesianGridRej) where
     {F <: Number, SpecHop <: Vector{F}, SiteHop <: Vector{Vector{F}}}
     HopRatesGridDsLij(p..., grid)
 end
@@ -51,7 +51,7 @@ function HopRates(p::Pair{SpecHop, SiteHop},
     HopRatesGraphDsiLij(p...)
 end
 function HopRates(p::Pair{SpecHop, SiteHop},
-                  grid::Union{CartesianGridRej, CartesianGridIter}) where
+                  grid::CartesianGridRej) where
     {SpecHop <: Matrix{F}, SiteHop <: Vector{Vector{F}}} where {F <: Number}
     HopRatesGridDsiLij(p..., grid)
 end

--- a/src/spatial/topology.jl
+++ b/src/spatial/topology.jl
@@ -144,31 +144,7 @@ function rand_nbr(rng, grid::CartesianGridRej, site::Int)
     end
 end
 
-# neighbor sampling is iterator-based
-struct CartesianGridIter{N, T}
-    dims::NTuple{N, Int}
-    nums_neighbors::Vector{Int}
-    CI::CartesianIndices{N, T}
-    LI::LinearIndices{N, T}
-    offsets::Vector{CartesianIndex{N}}
-end
-function CartesianGridIter(dims::Tuple)
-    dim = length(dims)
-    CI = CartesianIndices(dims)
-    LI = LinearIndices(dims)
-    offsets = potential_offsets(dim)
-    nums_neighbors = [count(x -> x + CI[site] in CI, offsets) for site in 1:prod(dims)]
-    CartesianGridIter(dims, nums_neighbors, CI, LI, offsets)
-end
-CartesianGridIter(dims) = CartesianGridIter(Tuple(dims))
-function CartesianGridIter(dimension, linear_size::Int)
-    CartesianGridIter([linear_size for i in 1:dimension])
-end
-function rand_nbr(rng, grid::CartesianGridIter, site::Int)
-    nth_nbr(grid, site, rand(rng, 1:outdegree(grid, site)))
-end
-
 function Base.show(io::IO, ::MIME"text/plain",
-                   grid::Union{CartesianGridRej, CartesianGridIter})
+                   grid::CartesianGridRej)
     println(io, "A Cartesian grid with dimensions $(grid.dims)")
 end

--- a/src/spatial/topology.jl
+++ b/src/spatial/topology.jl
@@ -144,30 +144,6 @@ function rand_nbr(rng, grid::CartesianGridRej, site::Int)
     end
 end
 
-# neighbor sampling is iterator-based
-struct CartesianGridIter{N, T}
-    dims::NTuple{N, Int}
-    nums_neighbors::Vector{Int8}
-    CI::CartesianIndices{N, T}
-    LI::LinearIndices{N, T}
-    offsets::Vector{CartesianIndex{N}}
-end
-function CartesianGridIter(dims::Tuple)
-    dim = length(dims)
-    CI = CartesianIndices(dims)
-    LI = LinearIndices(dims)
-    offsets = potential_offsets(dim)
-    nums_neighbors = Int8[count(x -> x + CI[site] in CI, offsets) for site in 1:prod(dims)]
-    CartesianGridIter(dims, nums_neighbors, CI, LI, offsets)
-end
-CartesianGridIter(dims) = CartesianGridIter(Tuple(dims))
-function CartesianGridIter(dimension, linear_size::Int)
-    CartesianGridIter([linear_size for i in 1:dimension])
-end
-function rand_nbr(rng, grid::CartesianGridIter, site::Int)
-    nth_nbr(grid, site, rand(rng, 1:outdegree(grid, site)))
-end
-
 function Base.show(io::IO, ::MIME"text/plain",
                    grid::CartesianGridRej)
     println(io, "A Cartesian grid with dimensions $(grid.dims)")

--- a/test/spatial/ABC.jl
+++ b/test/spatial/ABC.jl
@@ -46,7 +46,7 @@ function get_mean_end_state(jump_prob, Nsims)
 end
 
 # testing
-grids = [CartesianGridRej(dims), CartesianGridIter(dims), Graphs.grid(dims)]
+grids = [CartesianGridRej(dims), Graphs.grid(dims)]
 jump_problems = JumpProblem[JumpProblem(prob, NSM(), majumps,
                                         hopping_constants = hopping_constants,
                                         spatial_system = grid,

--- a/test/spatial/diffusion.jl
+++ b/test/spatial/diffusion.jl
@@ -60,7 +60,7 @@ rel_tol = 0.01
 times = 0.0:(tf / num_time_points):tf
 
 algs = [NSM(), DirectCRDirect()]
-grids = [CartesianGridRej(dims), CartesianGridIter(dims), Graphs.grid(dims)]
+grids = [CartesianGridRej(dims), Graphs.grid(dims)]
 jump_problems = JumpProblem[JumpProblem(prob, algs[2], majumps,
                                         hopping_constants = hopping_constants,
                                         spatial_system = grid,

--- a/test/spatial/diffusion.jl
+++ b/test/spatial/diffusion.jl
@@ -80,7 +80,7 @@ for alg in algs
                       spatial_system = grids[1], save_positions = (false, false)))
     push!(jump_problems,
           JumpProblem(prob, alg, majumps, hopping_constants = hop_constants,
-                      spatial_system = grids[3], save_positions = (false, false)))
+                      spatial_system = grids[end], save_positions = (false, false)))
 end
 
 # hop rates of form L_{s,i,j}
@@ -96,7 +96,7 @@ for alg in algs
                       spatial_system = grids[1], save_positions = (false, false)))
     push!(jump_problems,
           JumpProblem(prob, alg, majumps, hopping_constants = hop_constants,
-                      spatial_system = grids[3], save_positions = (false, false)))
+                      spatial_system = grids[end], save_positions = (false, false)))
 end
 
 # hop rates of form D_s * L_{i,j}
@@ -113,7 +113,7 @@ for alg in algs
     push!(jump_problems,
           JumpProblem(prob, alg, majumps,
                       hopping_constants = Pair(species_hop_constants, site_hop_constants),
-                      spatial_system = grids[3], save_positions = (false, false)))
+                      spatial_system = grids[end], save_positions = (false, false)))
 end
 
 # hop rates of form D_{s,i} * L_{i,j}
@@ -130,7 +130,7 @@ for alg in algs
     push!(jump_problems,
           JumpProblem(prob, alg, majumps,
                       hopping_constants = Pair(species_hop_constants, site_hop_constants),
-                      spatial_system = grids[3], save_positions = (false, false)))
+                      spatial_system = grids[end], save_positions = (false, false)))
 end
 
 # testing

--- a/test/spatial/topology.jl
+++ b/test/spatial/topology.jl
@@ -17,7 +17,6 @@ num_samples = 10^5
 rel_tol = 0.01
 grids = [
     JP.CartesianGridRej(dims),
-    JP.CartesianGridIter(dims),
     Graphs.grid(dims),
 ]
 for grid in grids


### PR DESCRIPTION
`CartesianGridRej` performs significantly better than `CartesianGridIter`.