### PR TITLE
remove unbound type parameters

### DIFF
--- a/src/aggregators/rdirect.jl
+++ b/src/aggregators/rdirect.jl
@@ -24,7 +24,7 @@ function RDirectJumpAggregation(nj::Int, njt::T, et::T, crs::Vector{T}, sr::T, m
                                 rs::F1, affs!::F2, sps::Tuple{Bool, Bool}, rng::RNG;
                                 num_specs, counter_threshold = length(crs),
                                 dep_graph = nothing,
-                                kwargs...) where {T, S, F1, F2, RNG, DEPGR}
+                                kwargs...) where {T, S, F1, F2, RNG}
     # a dependency graph is needed and must be provided if there are constant rate jumps
     if dep_graph === nothing
         if (get_num_majumps(maj) == 0) || !isempty(rs)

--- a/src/jumps.jl
+++ b/src/jumps.jl
@@ -249,12 +249,12 @@ function MassActionJump(usr::T, rs::S, ns::U, pmapper::V; scale_rates = true,
     MassActionJump{T, S, U, V}(usr, rs, ns, pmapper, scale_rates, useiszero, nocopy)
 end
 function MassActionJump(usr::T, rs, ns; scale_rates = true, useiszero = true,
-                        nocopy = false) where {T <: AbstractVector, S, U}
+                        nocopy = false) where {T <: AbstractVector}
     MassActionJump(usr, rs, ns, nothing; scale_rates = scale_rates, useiszero = useiszero,
                    nocopy = nocopy)
 end
 function MassActionJump(usr::T, rs, ns; scale_rates = true, useiszero = true,
-                        nocopy = false) where {T <: Number, S, U}
+                        nocopy = false) where {T <: Number}
     MassActionJump(usr, rs, ns, nothing; scale_rates = scale_rates, useiszero = useiszero,
                    nocopy = nocopy)
 end


### PR DESCRIPTION
Unbound type parameters often cause performance issues and run time dispatch.

Issue found using https://github.com/JuliaLang/julia/pull/46608