### PR TITLE
Modifies rateinterval API to accept computed `urate`.

### DIFF
--- a/test/hawkes_test.jl
+++ b/test/hawkes_test.jl
@@ -37,16 +37,13 @@ function hawkes_jump(i::Int, g, h; uselrate = true)
     urate = rate
     if uselrate
         lrate(u, p, t) = p[1]
-        rateinterval = (u, p, t) -> begin
-            _lrate = lrate(u, p, t)
-            _urate = urate(u, p, t)
-            return _urate == _lrate ? typemax(t) : 1 / (2 * _urate)
+        rateinterval = (u, p, t, urate) -> begin
+            return urate == p[1] ? typemax(t) : 1 / (2 * urate)
         end
     else
         lrate = nothing
-        rateinterval = (u, p, t) -> begin
-            _urate = urate(u, p, t)
-            return 1 / (2 * _urate)
+        rateinterval = (u, p, t, urate) -> begin
+            return 1 / (2 * urate)
         end
     end
     function affect!(integrator)


### PR DESCRIPTION
A problem with the current implementation of `Coevolve` is that it might compute `urate` twice. Once when computing the actual `urate` and another time if `rateinterval` calls `urate`.

This problem is clear in the Hakwes benchmark. Below you can see a profile of the simulation:

![image](https://user-images.githubusercontent.com/11043156/215500213-5565ea9f-5c5e-4c12-85f3-d083d30a4225.png)

This PR modifies the API of `rateinterval` to `rateinterval(u, p, t, urate)`. With this modification, you can see that much less time is spent in `rateinterval`.

![image](https://user-images.githubusercontent.com/11043156/215500885-cee09124-1c87-4ba0-8803-5c5375a02f54.png)

The downside is a more verbose API. The API will also break for when using `VariableRate` with `Coevolve`. However, since the aggregator is relatively new, it might be worth considering this change. I am happy to discuss more elegant alternatives. 