### PR TITLE
function wrapper type instability fix

### DIFF
--- a/src/aggregators/coevolve.jl
+++ b/src/aggregators/coevolve.jl
@@ -2,7 +2,7 @@
 Queue method. This method handles variable intensity rates.
 """
 mutable struct CoevolveJumpAggregation{T, S, F1, F2, RNG, GR, PQ} <:
-               AbstractSSAJumpAggregator
+               AbstractSSAJumpAggregator{T, S, F1, F2, RNG}
     next_jump::Int                    # the next jump to execute
     prev_jump::Int                    # the previous jump that was executed
     next_jump_time::T                 # the time of the next jump
@@ -46,7 +46,8 @@ function CoevolveJumpAggregation(nj::Int, njt::T, et::T, crs::Vector{T}, sr::Not
     end
 
     pq = MutableBinaryMinHeap{T}()
-    CoevolveJumpAggregation{T, S, F1, F2, RNG, typeof(dg),
+    affecttype = F2 <: Tuple ? F2 : Any
+    CoevolveJumpAggregation{T, S, F1, affecttype, RNG, typeof(dg),
                             typeof(pq)}(nj, nj, njt, et, crs, sr, maj, rs, affs!, sps, rng,
                                         dg, pq, lrates, urates, rateintervals, haslratevec)
 end
@@ -55,14 +56,13 @@ end
 function aggregate(aggregator::Coevolve, u, p, t, end_time, constant_jumps,
                    ma_jumps, save_positions, rng; dep_graph = nothing,
                    variable_jumps = nothing, kwargs...)
-    AffectWrapper = FunctionWrappers.FunctionWrapper{Nothing, Tuple{Any}}
     RateWrapper = FunctionWrappers.FunctionWrapper{typeof(t),
                                                    Tuple{typeof(u), typeof(p), typeof(t)}}
 
     ncrjs = (constant_jumps === nothing) ? 0 : length(constant_jumps)
     nvrjs = (variable_jumps === nothing) ? 0 : length(variable_jumps)
     nrjs = ncrjs + nvrjs
-    affects! = Vector{AffectWrapper}(undef, nrjs)
+    affects! = Vector{Any}(undef, nrjs)
     rates = Vector{RateWrapper}(undef, nvrjs)
     lrates = similar(rates)
     rateintervals = similar(rates)
@@ -72,7 +72,7 @@ function aggregate(aggregator::Coevolve, u, p, t, end_time, constant_jumps,
     idx = 1
     if constant_jumps !== nothing
         for crj in constant_jumps
-            affects![idx] = AffectWrapper(integ -> (crj.affect!(integ); nothing))
+            affects![idx] = integ -> (crj.affect!(integ); nothing)
             urates[idx] = RateWrapper(crj.rate)
             idx += 1
         end
@@ -80,7 +80,7 @@ function aggregate(aggregator::Coevolve, u, p, t, end_time, constant_jumps,
 
     if variable_jumps !== nothing
         for (i, vrj) in enumerate(variable_jumps)
-            affects![idx] = AffectWrapper(integ -> (vrj.affect!(integ); nothing))
+            affects![idx] = integ -> (vrj.affect!(integ); nothing)
             urates[idx] = RateWrapper(vrj.urate)
             idx += 1
             rates[i] = RateWrapper(vrj.rate)
@@ -109,9 +109,10 @@ function initialize!(p::CoevolveJumpAggregation, integrator, u, params, t)
 end
 
 # execute one jump, changing the system state
-function execute_jumps!(p::CoevolveJumpAggregation, integrator, u, params, t)
+function execute_jumps!(p::CoevolveJumpAggregation, integrator, u, params, t, affects!)
     # execute jump
-    u = update_state!(p, integrator, u)
+    u = update_state!(p, integrator, u, affects!)
+
     # update current jump rates and times
     update_dependent_rates!(p, u, params, t)
     nothing

--- a/src/aggregators/direct.jl
+++ b/src/aggregators/direct.jl
@@ -52,7 +52,8 @@ function initialize!(p::DirectJumpAggregation, integrator, u, params, t)
 end
 
 # execute one jump, changing the system state
-@inline function execute_jumps!(p::DirectJumpAggregation, integrator, u, params, t, affects!)
+@inline function execute_jumps!(p::DirectJumpAggregation, integrator, u, params, t,
+                                affects!)
     update_state!(p, integrator, u, affects!)
     nothing
 end

--- a/src/aggregators/directcr.jl
+++ b/src/aggregators/directcr.jl
@@ -12,7 +12,7 @@ const MINJUMPRATE = 2.0^exponent(1e-12)
 
 mutable struct DirectCRJumpAggregation{T, S, F1, F2, RNG, DEPGR, U <: PriorityTable,
                                        W <: Function} <:
-                                       AbstractSSAJumpAggregator{T, S, F1, F2, RNG}
+               AbstractSSAJumpAggregator{T, S, F1, F2, RNG}
     next_jump::Int
     prev_jump::Int
     next_jump_time::T

--- a/src/aggregators/directcr.jl
+++ b/src/aggregators/directcr.jl
@@ -11,7 +11,8 @@ by S. Mauch and M. Stalzer, ACM Trans. Comp. Biol. and Bioinf., 8, No. 1, 27-35 
 const MINJUMPRATE = 2.0^exponent(1e-12)
 
 mutable struct DirectCRJumpAggregation{T, S, F1, F2, RNG, DEPGR, U <: PriorityTable,
-                                       W <: Function} <: AbstractSSAJumpAggregator
+                                       W <: Function} <:
+                                       AbstractSSAJumpAggregator{T, S, F1, F2, RNG}
     next_jump::Int
     prev_jump::Int
     next_jump_time::T
@@ -61,7 +62,8 @@ function DirectCRJumpAggregation(nj::Int, njt::T, et::T, crs::Vector{T}, sr::T,
     # construct an empty initial priority table -- we'll reset this in init
     rt = PriorityTable(ratetogroup, zeros(T, 1), minrate, 2 * minrate)
 
-    DirectCRJumpAggregation{T, S, F1, F2, RNG, typeof(dg),
+    affecttype = F2 <: Tuple ? F2 : Any
+    DirectCRJumpAggregation{T, S, F1, affecttype, RNG, typeof(dg),
                             typeof(rt), typeof(ratetogroup)}(nj, nj, njt, et, crs, sr, maj,
                                                              rs, affs!, sps, rng, dg,
                                                              minrate, maxrate, rt,
@@ -100,9 +102,9 @@ function initialize!(p::DirectCRJumpAggregation, integrator, u, params, t)
 end
 
 # execute one jump, changing the system state
-function execute_jumps!(p::DirectCRJumpAggregation, integrator, u, params, t)
+function execute_jumps!(p::DirectCRJumpAggregation, integrator, u, params, t, affects!)
     # execute jump
-    u = update_state!(p, integrator, u)
+    u = update_state!(p, integrator, u, affects!)
 
     # update current jump rates
     update_dependent_rates!(p, u, params, t)

--- a/src/aggregators/frm.jl
+++ b/src/aggregators/frm.jl
@@ -1,4 +1,5 @@
-mutable struct FRMJumpAggregation{T, S, F1, F2, RNG} <: AbstractSSAJumpAggregator
+mutable struct FRMJumpAggregation{T, S, F1, F2, RNG} <:
+               AbstractSSAJumpAggregator{T, S, F1, F2, RNG}
     next_jump::Int
     prev_jump::Int
     next_jump_time::T
@@ -14,8 +15,9 @@ end
 function FRMJumpAggregation(nj::Int, njt::T, et::T, crs::Vector{T}, sr::T, maj::S, rs::F1,
                             affs!::F2, sps::Tuple{Bool, Bool}, rng::RNG;
                             kwargs...) where {T, S, F1, F2, RNG}
-    FRMJumpAggregation{T, S, F1, F2, RNG}(nj, nj, njt, et, crs, sr, maj, rs, affs!, sps,
-                                          rng)
+    affecttype = F2 <: Tuple ? F2 : Any
+    FRMJumpAggregation{T, S, F1, affecttype, RNG}(nj, nj, njt, et, crs, sr, maj, rs,
+                                                  affs!, sps, rng)
 end
 
 ############################# Required Functions #############################
@@ -50,9 +52,9 @@ function initialize!(p::FRMJumpAggregation, integrator, u, params, t)
 end
 
 # execute one jump, changing the system state
-@inline function execute_jumps!(p::FRMJumpAggregation, integrator, u, params, t)
+@inline function execute_jumps!(p::FRMJumpAggregation, integrator, u, params, t, affects!)
     # execute jump
-    update_state!(p, integrator, u)
+    update_state!(p, integrator, u, affects!)
     nothing
 end
 

--- a/src/aggregators/frm.jl
+++ b/src/aggregators/frm.jl
@@ -112,9 +112,8 @@ function next_constant_rate_jump(p::FRMJumpAggregation{T, S, F1, F2, RNG}, u, pa
 end
 
 # function wrapper-based constant jumps
-function next_constant_rate_jump(p::FRMJumpAggregation{T, S, F1, F2, RNG}, u, params,
-                                 t) where {T, S, F1 <: AbstractArray, F2 <: AbstractArray,
-                                           RNG}
+function next_constant_rate_jump(p::FRMJumpAggregation{T, S, F1}, u, params,
+                                 t) where {T, S, F1 <: AbstractArray}
     ttnj = typemax(typeof(t))
     nextrx = zero(Int)
     if !isempty(p.rates)

--- a/src/aggregators/nrm.jl
+++ b/src/aggregators/nrm.jl
@@ -1,7 +1,8 @@
 # Implementation the original Next Reaction Method
 # Gibson and Bruck, J. Phys. Chem. A, 104 (9), (2000)
 
-mutable struct NRMJumpAggregation{T, S, F1, F2, RNG, DEPGR, PQ} <: AbstractSSAJumpAggregator
+mutable struct NRMJumpAggregation{T, S, F1, F2, RNG, DEPGR, PQ} <:
+               AbstractSSAJumpAggregator{T, S, F1, F2, RNG}
     next_jump::Int
     prev_jump::Int
     next_jump_time::T
@@ -38,10 +39,11 @@ function NRMJumpAggregation(nj::Int, njt::T, et::T, crs::Vector{T}, sr::T,
 
     pq = MutableBinaryMinHeap{T}()
 
-    NRMJumpAggregation{T, S, F1, F2, RNG, typeof(dg), typeof(pq)}(nj, nj, njt, et, crs, sr,
-                                                                  maj,
-                                                                  rs, affs!, sps, rng, dg,
-                                                                  pq)
+    affecttype = F2 <: Tuple ? F2 : Any
+    NRMJumpAggregation{T, S, F1, affecttype, RNG, typeof(dg), typeof(pq)}(nj, nj, njt, et,
+                                                                          crs, sr, maj,
+                                                                          rs, affs!, sps,
+                                                                          rng, dg, pq)
 end
 
 +############################# Required Functions ##############################
@@ -66,9 +68,9 @@ function initialize!(p::NRMJumpAggregation, integrator, u, params, t)
 end
 
 # execute one jump, changing the system state
-function execute_jumps!(p::NRMJumpAggregation, integrator, u, params, t)
+function execute_jumps!(p::NRMJumpAggregation, integrator, u, params, t, affects!)
     # execute jump
-    u = update_state!(p, integrator, u)
+    u = update_state!(p, integrator, u, affects!)
 
     # update current jump rates and times
     update_dependent_rates!(p, u, params, t)

--- a/src/aggregators/rdirect.jl
+++ b/src/aggregators/rdirect.jl
@@ -2,7 +2,8 @@
 Direct with rejection sampling
 """
 
-mutable struct RDirectJumpAggregation{T, S, F1, F2, RNG, DEPGR} <: AbstractSSAJumpAggregator
+mutable struct RDirectJumpAggregation{T, S, F1, F2, RNG, DEPGR} <:
+               AbstractSSAJumpAggregator{T, S, F1, F2, RNG}
     next_jump::Int
     prev_jump::Int
     next_jump_time::T
@@ -40,10 +41,12 @@ function RDirectJumpAggregation(nj::Int, njt::T, et::T, crs::Vector{T}, sr::T, m
     end
 
     max_rate = maximum(crs)
-    return RDirectJumpAggregation{T, S, F1, F2, RNG, typeof(dg)}(nj, nj, njt, et, crs, sr,
-                                                                 maj, rs, affs!, sps, rng,
-                                                                 dg, max_rate, 0,
-                                                                 counter_threshold)
+    affecttype = F2 <: Tuple ? F2 : Any
+    return RDirectJumpAggregation{T, S, F1, affecttype, RNG, typeof(dg)}(nj, nj, njt, et,
+                                                                         crs, sr, maj, rs,
+                                                                         affs!, sps, rng,
+                                                                         dg, max_rate, 0,
+                                                                         counter_threshold)
 end
 
 ############################# Required Functions #############################
@@ -72,9 +75,9 @@ end
 """
 execute one jump, changing the system state and updating rates
 """
-function execute_jumps!(p::RDirectJumpAggregation, integrator, u, params, t)
+function execute_jumps!(p::RDirectJumpAggregation, integrator, u, params, t, affects!)
     # execute jump
-    u = update_state!(p, integrator, u)
+    u = update_state!(p, integrator, u, affects!)
 
     # update rates
     update_dependent_rates!(p, u, params, t)

--- a/src/aggregators/rssacr.jl
+++ b/src/aggregators/rssacr.jl
@@ -6,7 +6,7 @@ const MINJUMPRATE = 2.0^exponent(1e-12)
 
 mutable struct RSSACRJumpAggregation{F, U, S, F1, F2, RNG, VJMAP, JVMAP, BD, T2V,
                                      P <: PriorityTable, W <: Function} <:
-               AbstractSSAJumpAggregator
+               AbstractSSAJumpAggregator{F, S, F1, F2, RNG}
     next_jump::Int
     prev_jump::Int
     next_jump_time::F
@@ -82,7 +82,8 @@ function RSSACRJumpAggregation(nj::Int, njt::F, et::F, crs::Vector{F}, sum_rate:
     # construct an empty initial priority table -- we'll reset this in init
     rt = PriorityTable(ratetogroup, zeros(F, 1), minrate, 2 * minrate)
 
-    RSSACRJumpAggregation{typeof(njt), eltype(U), S, F1, F2, RNG, typeof(vtoj_map),
+    affecttype = F2 <: Tuple ? F2 : Any
+    RSSACRJumpAggregation{typeof(njt), eltype(U), S, F1, affecttype, RNG, typeof(vtoj_map),
                           typeof(jtov_map), typeof(bd), typeof(ulow), typeof(rt),
                           typeof(ratetogroup)}(nj, nj, njt, et, crl_bnds, crh_bnds,
                                                sum_rate, maj, rs, affs!, sps, rng, vtoj_map,
@@ -119,9 +120,9 @@ function initialize!(p::RSSACRJumpAggregation, integrator, u, params, t)
 end
 
 # execute one jump, changing the system state
-function execute_jumps!(p::RSSACRJumpAggregation, integrator, u, params, t)
+function execute_jumps!(p::RSSACRJumpAggregation, integrator, u, params, t, affects!)
     # execute jump
-    u = update_state!(p, integrator, u)
+    u = update_state!(p, integrator, u, affects!)
 
     # update rates
     update_dependent_rates!(p, u, params, t)

--- a/src/aggregators/rssacr.jl
+++ b/src/aggregators/rssacr.jl
@@ -4,7 +4,7 @@ Composition-Rejection with Rejection sampling method (RSSA-CR)
 
 const MINJUMPRATE = 2.0^exponent(1e-12)
 
-mutable struct RSSACRJumpAggregation{F, U, S, F1, F2, RNG, VJMAP, JVMAP, BD, T2V,
+mutable struct RSSACRJumpAggregation{F, S, F1, F2, RNG, U, VJMAP, JVMAP, BD, T2V,
                                      P <: PriorityTable, W <: Function} <:
                AbstractSSAJumpAggregator{F, S, F1, F2, RNG}
     next_jump::Int
@@ -32,8 +32,7 @@ mutable struct RSSACRJumpAggregation{F, U, S, F1, F2, RNG, VJMAP, JVMAP, BD, T2V
 end
 
 function RSSACRJumpAggregation(nj::Int, njt::F, et::F, crs::Vector{F}, sum_rate::F, maj::S,
-                               rs::F1,
-                               affs!::F2, sps::Tuple{Bool, Bool}, rng::RNG; u::U,
+                               rs::F1, affs!::F2, sps::Tuple{Bool, Bool}, rng::RNG; u::U,
                                vartojumps_map = nothing, jumptovars_map = nothing,
                                bracket_data = nothing, minrate = convert(F, MINJUMPRATE),
                                maxrate = convert(F, Inf),
@@ -83,7 +82,7 @@ function RSSACRJumpAggregation(nj::Int, njt::F, et::F, crs::Vector{F}, sum_rate:
     rt = PriorityTable(ratetogroup, zeros(F, 1), minrate, 2 * minrate)
 
     affecttype = F2 <: Tuple ? F2 : Any
-    RSSACRJumpAggregation{typeof(njt), eltype(U), S, F1, affecttype, RNG, typeof(vtoj_map),
+    RSSACRJumpAggregation{typeof(njt), S, F1, affecttype, RNG, eltype(U), typeof(vtoj_map),
                           typeof(jtov_map), typeof(bd), typeof(ulow), typeof(rt),
                           typeof(ratetogroup)}(nj, nj, njt, et, crl_bnds, crh_bnds,
                                                sum_rate, maj, rs, affs!, sps, rng, vtoj_map,

--- a/src/aggregators/sortingdirect.jl
+++ b/src/aggregators/sortingdirect.jl
@@ -3,7 +3,7 @@
 # Comp. Bio. and Chem., 30, pg. 39-49 (2006).
 
 mutable struct SortingDirectJumpAggregation{T, S, F1, F2, RNG, DEPGR} <:
-               AbstractSSAJumpAggregator
+               AbstractSSAJumpAggregator{T, S, F1, F2, RNG}
     next_jump::Int
     prev_jump::Int
     next_jump_time::T
@@ -41,9 +41,12 @@ function SortingDirectJumpAggregation(nj::Int, njt::T, et::T, crs::Vector{T}, sr
 
     # map jump idx to idx in cur_rates
     jtoidx = collect(1:length(crs))
-    SortingDirectJumpAggregation{T, S, F1, F2, RNG, typeof(dg)}(nj, nj, njt, et, crs, sr,
-                                                                maj, rs, affs!, sps, rng,
-                                                                dg, jtoidx, zero(Int))
+    affecttype = F2 <: Tuple ? F2 : Any
+    SortingDirectJumpAggregation{T, S, F1, affecttype, RNG, typeof(dg)}(nj, nj, njt, et,
+                                                                        crs, sr, maj, rs,
+                                                                        affs!, sps, rng,
+                                                                        dg, jtoidx,
+                                                                        zero(Int))
 end
 
 ############################# Required Functions ##############################
@@ -69,9 +72,9 @@ function initialize!(p::SortingDirectJumpAggregation, integrator, u, params, t)
 end
 
 # execute one jump, changing the system state
-function execute_jumps!(p::SortingDirectJumpAggregation, integrator, u, params, t)
+function execute_jumps!(p::SortingDirectJumpAggregation, integrator, u, params, t, affects!)
     # execute jump
-    u = update_state!(p, integrator, u)
+    u = update_state!(p, integrator, u, affects!)
 
     # update search order
     jso = p.jump_search_order

--- a/src/aggregators/ssajump.jl
+++ b/src/aggregators/ssajump.jl
@@ -66,12 +66,12 @@ end
 end
 
 # executing jump at the next jump time
-function (p::AbstractSSAJumpAggregator)(integrator::DiffEqBase.DEIntegrator)
+function (p::AbstractSSAJumpAggregator)(integrator::I) where {I <: DiffEqBase.DEIntegrator}
     affects! = p.affects!
     if affects! isa Vector{FunctionWrappers.FunctionWrapper{Nothing, Tuple{I}}}
         execute_jumps!(p, integrator, integrator.u, integrator.p, integrator.t, affects!)
     else
-        error("Error, invalid affects! type in $(typeof(p))")
+        error("Error, invalid affects! type. Expected a vector of function wrappers and got $(typeof(affects!))")
     end
     generate_jumps!(p, integrator, integrator.u, integrator.p, integrator.t)
     register_next_jump_time!(integrator, p, integrator.t)

--- a/src/aggregators/ssajump.jl
+++ b/src/aggregators/ssajump.jl
@@ -78,7 +78,8 @@ function (p::AbstractSSAJumpAggregator)(integrator::I) where {I <: DiffEqBase.DE
     nothing
 end
 
-function (p::AbstractSSAJumpAggregator{T, S, F1, F2})(integrator::DiffEqBase.DEIntegrator) where {T, S, F1, F2 <: Union{Tuple, Nothing}}
+function (p::AbstractSSAJumpAggregator{T, S, F1, F2})(integrator::DiffEqBase.DEIntegrator) where
+    {T, S, F1, F2 <: Union{Tuple, Nothing}}
     execute_jumps!(p, integrator, integrator.u, integrator.p, integrator.t, p.affects!)
     generate_jumps!(p, integrator, integrator.u, integrator.p, integrator.t)
     register_next_jump_time!(integrator, p, integrator.t)

--- a/src/aggregators/ssajump.jl
+++ b/src/aggregators/ssajump.jl
@@ -78,7 +78,7 @@ function (p::AbstractSSAJumpAggregator)(integrator::I) where {I <: DiffEqBase.DE
     nothing
 end
 
-function (p::AbstractSSAJumpAggregator{T, S, F1, F2})(integrator::DiffEqBase.DEIntegrator) where {T, S, F1, F2 <: Tuple}
+function (p::AbstractSSAJumpAggregator{T, S, F1, F2})(integrator::DiffEqBase.DEIntegrator) where {T, S, F1, F2 <: Union{Tuple, Nothing}}
     execute_jumps!(p, integrator, integrator.u, integrator.p, integrator.t, p.affects!)
     generate_jumps!(p, integrator, integrator.u, integrator.p, integrator.t)
     register_next_jump_time!(integrator, p, integrator.t)

--- a/src/jumps.jl
+++ b/src/jumps.jl
@@ -691,22 +691,6 @@ end
 function get_jump_info_fwrappers(u, p, t, constant_jumps)
     RateWrapper = FunctionWrappers.FunctionWrapper{typeof(t),
                                                    Tuple{typeof(u), typeof(p), typeof(t)}}
-    AffectWrapper = FunctionWrappers.FunctionWrapper{Nothing, Tuple{Any}}
-
-    if (constant_jumps !== nothing) && !isempty(constant_jumps)
-        rates = [RateWrapper(c.rate) for c in constant_jumps]
-        affects! = [AffectWrapper(x -> (c.affect!(x); nothing)) for c in constant_jumps]
-    else
-        rates = Vector{RateWrapper}()
-        affects! = Vector{AffectWrapper}()
-    end
-
-    rates, affects!
-end
-
-function get_jump_info_fwrappers_direct(u, p, t, constant_jumps)
-    RateWrapper = FunctionWrappers.FunctionWrapper{typeof(t),
-                                                   Tuple{typeof(u), typeof(p), typeof(t)}}
 
     if (constant_jumps !== nothing) && !isempty(constant_jumps)
         rates = [RateWrapper(c.rate) for c in constant_jumps]

--- a/src/jumps.jl
+++ b/src/jumps.jl
@@ -703,3 +703,18 @@ function get_jump_info_fwrappers(u, p, t, constant_jumps)
 
     rates, affects!
 end
+
+function get_jump_info_fwrappers_direct(u, p, t, constant_jumps)
+    RateWrapper = FunctionWrappers.FunctionWrapper{typeof(t),
+                                                   Tuple{typeof(u), typeof(p), typeof(t)}}
+
+    if (constant_jumps !== nothing) && !isempty(constant_jumps)
+        rates = [RateWrapper(c.rate) for c in constant_jumps]
+        affects! = Any[(x -> (c.affect!(x); nothing)) for c in constant_jumps]
+    else
+        rates = Vector{RateWrapper}()
+        affects! = Any[]
+    end
+
+    rates, affects!
+end

--- a/src/spatial/directcrdirect.jl
+++ b/src/spatial/directcrdirect.jl
@@ -5,9 +5,10 @@ const MINJUMPRATE = 2.0^exponent(1e-12)
 
 #NOTE state vector u is a matrix. u[i,j] is species i, site j
 #NOTE hopping_constants is a matrix. hopping_constants[i,j] is species i, site j
-mutable struct DirectCRDirectJumpAggregation{J, T, RX, HOP, RNG, DEPGR, VJMAP, JVMAP, SS,
-                                             U <: PriorityTable, W <: Function} <:
-               AbstractSSAJumpAggregator
+mutable struct DirectCRDirectJumpAggregation{T, S, F1, F2, RNG, J, RX, HOP, DEPGR,
+                                             VJMAP, JVMAP, SS, U <: PriorityTable,
+                                             W <: Function} <:
+               AbstractSSAJumpAggregator{T, S, F1, F2, RNG}
     next_jump::SpatialJump{J} #some structure to identify the next event: reaction or hop
     prev_jump::SpatialJump{J} #some structure to identify the previous event: reaction or hop
     next_jump_time::T
@@ -68,7 +69,7 @@ function DirectCRDirectJumpAggregation(nj::SpatialJump{J}, njt::T, et::T, rx_rat
     # construct an empty initial priority table -- we'll reset this in init
     rt = PriorityTable(ratetogroup, zeros(T, 1), minrate, 2 * minrate)
 
-    DirectCRDirectJumpAggregation{J, T, RX, HOP, RNG,
+    DirectCRDirectJumpAggregation{T, Nothing, Nothing, Nothing, RNG, J, RX, HOP,
                                   typeof(dg), typeof(vtoj_map),
                                   typeof(jtov_map), SS, typeof(rt),
                                   typeof(ratetogroup)}(nj, nj, njt, et, rx_rates, hop_rates,
@@ -119,7 +120,8 @@ function generate_jumps!(p::DirectCRDirectJumpAggregation, integrator, params, u
 end
 
 # execute one jump, changing the system state
-function execute_jumps!(p::DirectCRDirectJumpAggregation, integrator, u, params, t)
+function execute_jumps!(p::DirectCRDirectJumpAggregation, integrator, u, params, t,
+                        affects!)
     # execute jump
     update_state!(p, integrator)
 

--- a/src/spatial/directcrdirect.jl
+++ b/src/spatial/directcrdirect.jl
@@ -16,8 +16,8 @@ mutable struct DirectCRDirectJumpAggregation{T, S, F1, F2, RNG, J, RX, HOP, DEPG
     rx_rates::RX
     hop_rates::HOP
     site_rates::Vector{T}
-    # rates::F1 #rates for constant-rate jumps
-    # affects!::F2 #affects! function determines the effect of constant-rate jumps
+    rates::F1 #rates for constant-rate jumps
+    affects!::F2 #affects! function determines the effect of constant-rate jumps
     save_positions::Tuple{Bool, Bool}
     rng::RNG
     dep_gr::DEPGR #dep graph is same for each site
@@ -73,7 +73,8 @@ function DirectCRDirectJumpAggregation(nj::SpatialJump{J}, njt::T, et::T, rx_rat
                                   typeof(dg), typeof(vtoj_map),
                                   typeof(jtov_map), SS, typeof(rt),
                                   typeof(ratetogroup)}(nj, nj, njt, et, rx_rates, hop_rates,
-                                                       site_rates, sps, rng, dg, vtoj_map,
+                                                       site_rates, nothing, nothing, sps,
+                                                       rng, dg, vtoj_map,
                                                        jtov_map, spatial_system, num_specs,
                                                        rt, ratetogroup)
 end

--- a/src/spatial/nsm.jl
+++ b/src/spatial/nsm.jl
@@ -12,8 +12,8 @@ mutable struct NSMJumpAggregation{T, S, F1, F2, RNG, J, RX, HOP, DEPGR, VJMAP, J
     end_time::T
     rx_rates::RX
     hop_rates::HOP
-    # rates::F1 #rates for constant-rate jumps
-    # affects!::F2 #affects! function determines the effect of constant-rate jumps
+    rates::F1 #rates for constant-rate jumps
+    affects!::F2 #affects! function determines the effect of constant-rate jumps
     save_positions::Tuple{Bool, Bool}
     rng::RNG
     dep_gr::DEPGR #dep graph is same for each site
@@ -58,6 +58,8 @@ function NSMJumpAggregation(nj::SpatialJump{J}, njt::T, et::T, rx_rates::RX, hop
                        typeof(vtoj_map), typeof(jtov_map), typeof(pq), SS}(nj, nj, njt, et,
                                                                            rx_rates,
                                                                            hop_rates,
+                                                                           nothing,
+                                                                           nothing,
                                                                            sps, rng, dg,
                                                                            vtoj_map,
                                                                            jtov_map,

--- a/src/spatial/nsm.jl
+++ b/src/spatial/nsm.jl
@@ -3,8 +3,9 @@
 ############################ NSM ###################################
 #NOTE state vector u is a matrix. u[i,j] is species i, site j
 #NOTE hopping_constants is a matrix. hopping_constants[i,j] is species i, site j
-mutable struct NSMJumpAggregation{J, T, RX, HOP, RNG, DEPGR, VJMAP, JVMAP, PQ, SS} <:
-               AbstractSSAJumpAggregator
+mutable struct NSMJumpAggregation{T, S, F1, F2, RNG, J, RX, HOP, DEPGR, VJMAP, JVMAP,
+                                  PQ, SS} <:
+               AbstractSSAJumpAggregator{T, S, F1, F2, RNG}
     next_jump::SpatialJump{J} #some structure to identify the next event: reaction or hop
     prev_jump::SpatialJump{J} #some structure to identify the previous event: reaction or hop
     next_jump_time::T
@@ -53,9 +54,16 @@ function NSMJumpAggregation(nj::SpatialJump{J}, njt::T, et::T, rx_rates::RX, hop
 
     pq = MutableBinaryMinHeap{T}()
 
-    NSMJumpAggregation{J, T, RX, HOP, RNG, typeof(dg), typeof(vtoj_map), typeof(jtov_map),
-                       typeof(pq), SS}(nj, nj, njt, et, rx_rates, hop_rates, sps, rng, dg,
-                                       vtoj_map, jtov_map, pq, spatial_system, num_specs)
+    NSMJumpAggregation{T, Nothing, Nothing, Nothing, RNG, J, RX, HOP, typeof(dg),
+                       typeof(vtoj_map), typeof(jtov_map), typeof(pq), SS}(nj, nj, njt, et,
+                                                                           rx_rates,
+                                                                           hop_rates,
+                                                                           sps, rng, dg,
+                                                                           vtoj_map,
+                                                                           jtov_map,
+                                                                           pq,
+                                                                           spatial_system,
+                                                                           num_specs)
 end
 
 ############################# Required Functions ##############################
@@ -98,7 +106,7 @@ function generate_jumps!(p::NSMJumpAggregation, integrator, params, u, t)
 end
 
 # execute one jump, changing the system state
-function execute_jumps!(p::NSMJumpAggregation, integrator, u, params, t)
+function execute_jumps!(p::NSMJumpAggregation, integrator, u, params, t, affects!)
     # execute jump
     update_state!(p, integrator)
 

--- a/test/bimolerx_test.jl
+++ b/test/bimolerx_test.jl
@@ -14,8 +14,7 @@ dotestmean = true
 doprintmeans = false
 
 # SSAs to test
-SSAalgs = (RDirect(), RSSACR(), Direct(), DirectFW(), FRM(), FRMFW(), SortingDirect(),
-           NRM(), RSSA(), DirectCR(), Coevolve())
+SSAalgs = JumpProcesses.JUMP_AGGREGATORS
 
 Nsims = 32000
 tf = 0.01


### PR DESCRIPTION
@ChrisRackauckas what do you think about this approach? Basically, when not using tuples for affects we store them as `affects!::Any` (but they are concretely a `Vector{Any}`). When `init` is called the `Vector{Any}` that is stored is concretized into a vector of type-stable function wrappers using the integrator type as input. Then I add a manual dispatch when `affects!` isn't a tuple to handle pulling out this vector from the `affects!::Any` field.

Preliminary testing is that overall I'm seeing a half-percent or less speed decrease when using `Direct` with tuples (so still much faster than before the recent generated function approach I put in), but a ~17% or more speed up when using function wrappers. Moreover, the memory allocation issues go away, so I think we now have type-stability outside the highest level call into the jump aggregator callback.

If this approach looks reasonable I'll cleanup and refactor the code from `Direct` to work with all the SSAs. 

One nice thing about the setup here is that it wouldn't be too bad to support affect! tuples for any method now, which can give a nice speed up (Direct vs. DirectFW on a small system is still like a 40% speed difference). We might want to add a similar manual dispatch for `rate` functions so that we can also support them as tuples with other SSAs. I’m thinking we could then switch based on the number of jumps to automatically use tuples vs. function wrappers for any method. 