### PR TITLE
Setfields for jump problems

### DIFF
--- a/src/JumpProcesses.jl
+++ b/src/JumpProcesses.jl
@@ -7,7 +7,7 @@ using RandomNumbers, TreeViews, LinearAlgebra, Markdown, DocStringExtensions
 using DataStructures, PoissonRandom, Random, ArrayInterface
 using FunctionWrappers, UnPack
 using Graphs
-using SciMLBase: SciMLBase
+using SciMLBase: SciMLBase, ___internal_setindex!
 using Base.FastMath: add_fast
 
 import DiffEqBase: DiscreteCallback, init, solve, solve!, plot_indices, initialize!

--- a/src/JumpProcesses.jl
+++ b/src/JumpProcesses.jl
@@ -7,7 +7,7 @@ using RandomNumbers, TreeViews, LinearAlgebra, Markdown, DocStringExtensions
 using DataStructures, PoissonRandom, Random, ArrayInterface
 using FunctionWrappers, UnPack
 using Graphs
-using SciMLBase: SciMLBase, ___internal_setindex!
+using SciMLBase: SciMLBase
 using Base.FastMath: add_fast
 
 import DiffEqBase: DiscreteCallback, init, solve, solve!, plot_indices, initialize!

--- a/src/problem.jl
+++ b/src/problem.jl
@@ -121,7 +121,7 @@ end
 
 # when setindex! is used.
 function Base.setindex!(prob::JumpProblem, args...; kwargs...)
-    ___internal_setindex!(prob.prob, args...; kwargs...)
+   SciMLBase.___internal_setindex!(prob.prob, args...; kwargs...)
     if using_params(prob.massaction_jump)
         update_parameters!(prob.massaction_jump, prob.prob.p)
     end

--- a/src/problem.jl
+++ b/src/problem.jl
@@ -122,8 +122,13 @@ end
 # when setindex! is used.
 function Base.setindex!(prob::JumpProblem, args...; kwargs...)
     ___internal_setindex!(prob.prob, args...; kwargs...)
-    update_parameters!(prob.massaction_jump, prob.dprob.p; kwargs...)
+    if using_params(prob.massaction_jump)
+        update_parameters!(prob.massaction_jump, prob.prob.p)
+    end
 end
+
+# when getindex is used.
+Base.getindex(prob::JumpProblem, args...; kwargs...) = Base.getindex(prob.prob, args...; kwargs...)
 
 DiffEqBase.isinplace(::JumpProblem{iip}) where {iip} = iip
 JumpProblem(prob::JumpProblem) = prob

--- a/src/problem.jl
+++ b/src/problem.jl
@@ -121,7 +121,7 @@ end
 
 # when setindex! is used.
 function Base.setindex!(prob::JumpProblem, args...; kwargs...)
-   SciMLBase.___internal_setindex!(prob.prob, args...; kwargs...)
+    SciMLBase.___internal_setindex!(prob.prob, args...; kwargs...)
     if using_params(prob.massaction_jump)
         update_parameters!(prob.massaction_jump, prob.prob.p)
     end

--- a/src/problem.jl
+++ b/src/problem.jl
@@ -128,7 +128,9 @@ function Base.setindex!(prob::JumpProblem, args...; kwargs...)
 end
 
 # when getindex is used.
-Base.getindex(prob::JumpProblem, args...; kwargs...) = Base.getindex(prob.prob, args...; kwargs...)
+function Base.getindex(prob::JumpProblem, args...; kwargs...)
+    Base.getindex(prob.prob, args...; kwargs...)
+end
 
 DiffEqBase.isinplace(::JumpProblem{iip}) where {iip} = iip
 JumpProblem(prob::JumpProblem) = prob

--- a/src/problem.jl
+++ b/src/problem.jl
@@ -119,6 +119,12 @@ function DiffEqBase.remake(thing::JumpProblem; kwargs...)
       thing.kwargs)
 end
 
+# when setindex! is used.
+function Base.setindex!(prob::JumpProblem, args...; kwargs...)
+    ___internal_setindex!(prob.prob, args...; kwargs...)
+    update_parameters!(prob.massaction_jump, prob.dprob.p; kwargs...)
+end
+
 DiffEqBase.isinplace(::JumpProblem{iip}) where {iip} = iip
 JumpProblem(prob::JumpProblem) = prob
 

--- a/test/jprob_symbol_indexing.jl
+++ b/test/jprob_symbol_indexing.jl
@@ -1,13 +1,14 @@
 # prepares the problem
 using JumpProcesses, Test
-rate1(u,p,t) = p[1]
-rate2(u,p,t) = p[2]
-affect1!(integ) = (integ.u[1] +=1)
+rate1(u, p, t) = p[1]
+rate2(u, p, t) = p[2]
+affect1!(integ) = (integ.u[1] += 1)
 affect2!(integ) = (integ.u[2] += 1)
 crj1 = ConstantRateJump(rate1, affect1!)
 crj2 = ConstantRateJump(rate2, affect2!)
-g = DiscreteFunction((du,u,p,t) -> nothing; syms = [:a, :b], paramsyms = [:p1, :p2])
-dprob = DiscreteProblem(g, [0, 10], (0.0, 10.0), [1.0, 2.0]; syms = [:a, :b], paramsyms = [:p1, :p2])
+g = DiscreteFunction((du, u, p, t) -> nothing; syms = [:a, :b], paramsyms = [:p1, :p2])
+dprob = DiscreteProblem(g, [0, 10], (0.0, 10.0), [1.0, 2.0]; syms = [:a, :b],
+                        paramsyms = [:p1, :p2])
 jprob = JumpProblem(dprob, Direct(), crj1, crj2)
 
 # runs the tests

--- a/test/jprob_symbol_indexing.jl
+++ b/test/jprob_symbol_indexing.jl
@@ -7,8 +7,7 @@ affect2!(integ) = (integ.u[2] += 1)
 crj1 = ConstantRateJump(rate1, affect1!)
 crj2 = ConstantRateJump(rate2, affect2!)
 g = DiscreteFunction((du, u, p, t) -> nothing; syms = [:a, :b], paramsyms = [:p1, :p2])
-dprob = DiscreteProblem(g, [0, 10], (0.0, 10.0), [1.0, 2.0]; syms = [:a, :b],
-                        paramsyms = [:p1, :p2])
+dprob = DiscreteProblem(g, [0, 10], (0.0, 10.0), [1.0, 2.0])
 jprob = JumpProblem(dprob, Direct(), crj1, crj2)
 
 # runs the tests
@@ -16,3 +15,5 @@ jprob = JumpProblem(dprob, Direct(), crj1, crj2)
 @test jprob[:b] == 10
 @test jprob[:p1] == 1.0
 @test jprob[:p2] == 2.0
+
+# tests for setindex (e.g. `jprob[:a] = 10`) not possible, this requires the problem to have a .f.sys filed.,

--- a/test/jprob_symbol_indexing.jl
+++ b/test/jprob_symbol_indexing.jl
@@ -1,0 +1,17 @@
+# prepares the problem
+using JumpProcesses, Test
+rate1(u,p,t) = p[1]
+rate2(u,p,t) = p[2]
+affect1!(integ) = (integ.u[1] +=1)
+affect2!(integ) = (integ.u[2] += 1)
+crj1 = ConstantRateJump(rate1, affect1!)
+crj2 = ConstantRateJump(rate2, affect2!)
+g = DiscreteFunction((du,u,p,t) -> nothing; syms = [:a, :b], paramsyms = [:p1, :p2])
+dprob = DiscreteProblem(g, [0, 10], (0.0, 10.0), [1.0, 2.0]; syms = [:a, :b], paramsyms = [:p1, :p2])
+jprob = JumpProblem(dprob, Direct(), crj1, crj2)
+
+# runs the tests
+@test jprob[:a] == 0
+@test jprob[:b] == 10
+@test jprob[:p1] == 1.0
+@test jprob[:p2] == 2.0

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -31,5 +31,5 @@ using JumpProcesses, DiffEqBase, SafeTestsets
     @time @safetestset "Spatial A + B <--> C" begin include("spatial/ABC.jl") end
     @time @safetestset "Spatially Varying Reaction Rates" begin include("spatial/spatial_majump.jl") end
     @time @safetestset "Pure diffusion" begin include("spatial/diffusion.jl") end
-    @time @safetestset "Symbol based problem indexing" begin include("jprob_symbol_indexing.jl") end    
+    @time @safetestset "Symbol based problem indexing" begin include("jprob_symbol_indexing.jl") end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -31,4 +31,5 @@ using JumpProcesses, DiffEqBase, SafeTestsets
     @time @safetestset "Spatial A + B <--> C" begin include("spatial/ABC.jl") end
     @time @safetestset "Spatially Varying Reaction Rates" begin include("spatial/spatial_majump.jl") end
     @time @safetestset "Pure diffusion" begin include("spatial/diffusion.jl") end
+    @time @safetestset "Symbol based problem indexing" begin include("jprob_symbol_indexing.jl") end    
 end


### PR DESCRIPTION
Two things:

enables `setdinex!` and `getindex` for `JumpProblems. E.g.
```julia
using Catalyst, JumpProcesses
rn = @reaction_network begin
    (p,d), 0 <--> X
end

u0 = [:X => 0]
p = [:p => 1.0, :d => 0.1]
dp = DiscreteProblem(rn,u0,(0.0,10.0),p)
jp = JumpProblem(rn,dp,Direct())

jp[:X]
jp[:p]
jp[:p] = 1.5
jp[:X] = 15
```

It also adds a check so that if `setindex!` is called on a `JumpProblem` then `update_parameters!(prob.massaction_jump, prob.prob.p)` is also called