### PR TITLE
Fix rssa allocations

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "JumpProcesses"
 uuid = "ccbc3e58-028d-4f4c-8cd5-9ae44345cda5"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "9.6.1"
+version = "9.6.2"
 
 [deps]
 ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"

--- a/src/aggregators/bracketing.jl
+++ b/src/aggregators/bracketing.jl
@@ -64,13 +64,27 @@ get brackets for reaction rx by first checking if the reaction is a massaction r
     end
 end
 
-# set up bracketing
-function set_bracketing!(p::AbstractSSAJumpAggregator, u, params, t)
-    # species bracketing interval
+function update_u_brackets!(p::AbstractSSAJumpAggregator, u::AbstractVector)
     @unpack ulow, uhigh = p
     @inbounds for (i, uval) in enumerate(u)
         ulow[i], uhigh[i] = get_spec_brackets(p.bracket_data, i, uval)
     end
+    nothing
+end
+
+function update_u_brackets!(p::AbstractSSAJumpAggregator, u::SVector)
+    @inbounds for (i, uval) in enumerate(u)
+        ulow, uhigh = get_spec_brackets(p.bracket_data, i, uval)
+        p.ulow = setindex(p.ulow, ulow, i)
+        p.uhigh = setindex(p.uhigh, uhigh, i)
+    end
+    nothing
+end
+
+# set up bracketing
+function set_bracketing!(p::AbstractSSAJumpAggregator, u, params, t)
+    # species bracketing interval
+    update_u_brackets!(p, u)
 
     # reaction rate bracketing interval
     # mass action jumps

--- a/src/aggregators/bracketing.jl
+++ b/src/aggregators/bracketing.jl
@@ -64,7 +64,7 @@ get brackets for reaction rx by first checking if the reaction is a massaction r
     end
 end
 
-function update_u_brackets!(p::AbstractSSAJumpAggregator, u::AbstractVector)
+@inline function update_u_brackets!(p::AbstractSSAJumpAggregator, u::AbstractVector)
     @unpack ulow, uhigh = p
     @inbounds for (i, uval) in enumerate(u)
         ulow[i], uhigh[i] = get_spec_brackets(p.bracket_data, i, uval)
@@ -72,7 +72,7 @@ function update_u_brackets!(p::AbstractSSAJumpAggregator, u::AbstractVector)
     nothing
 end
 
-function update_u_brackets!(p::AbstractSSAJumpAggregator, u::SVector)
+@inline function update_u_brackets!(p::AbstractSSAJumpAggregator, u::SVector)
     @inbounds for (i, uval) in enumerate(u)
         ulow, uhigh = get_spec_brackets(p.bracket_data, i, uval)
         p.ulow = setindex(p.ulow, ulow, i)

--- a/src/aggregators/bracketing.jl
+++ b/src/aggregators/bracketing.jl
@@ -67,9 +67,9 @@ end
 # set up bracketing
 function set_bracketing!(p::AbstractSSAJumpAggregator, u, params, t)
     # species bracketing interval
-    ubnds = p.cur_u_bnds
+    @unpack ulow, uhigh = p
     @inbounds for (i, uval) in enumerate(u)
-        ubnds[1, i], ubnds[2, i] = get_spec_brackets(p.bracket_data, i, uval)
+        ulow[i], uhigh[i] = get_spec_brackets(p.bracket_data, i, uval)
     end
 
     # reaction rate bracketing interval

--- a/src/aggregators/rssa.jl
+++ b/src/aggregators/rssa.jl
@@ -4,7 +4,7 @@
 # functions of the current population sizes (i.e. u)
 # requires vartojumps_map and fluct_rates as JumpProblem keywords
 
-mutable struct RSSAJumpAggregation{T, T2, S, F1, F2, RNG, VJMAP, JVMAP, BD, T2V} <:
+mutable struct RSSAJumpAggregation{T, S, F1, F2, RNG, VJMAP, JVMAP, BD, U} <:
                AbstractSSAJumpAggregator{T, S, F1, F2, RNG}
     next_jump::Int
     prev_jump::Int
@@ -13,7 +13,6 @@ mutable struct RSSAJumpAggregation{T, T2, S, F1, F2, RNG, VJMAP, JVMAP, BD, T2V}
     cur_rate_low::Vector{T}
     cur_rate_high::Vector{T}
     sum_rate::T
-    cur_u_bnds::Matrix{T2}
     ma_jumps::S
     rates::F1
     affects!::F2
@@ -22,8 +21,8 @@ mutable struct RSSAJumpAggregation{T, T2, S, F1, F2, RNG, VJMAP, JVMAP, BD, T2V}
     vartojumps_map::VJMAP
     jumptovars_map::JVMAP
     bracket_data::BD
-    ulow::T2V
-    uhigh::T2V
+    ulow::U
+    uhigh::U
 end
 
 function RSSAJumpAggregation(nj::Int, njt::T, et::T, crs::Vector{T}, sr::T,
@@ -59,20 +58,16 @@ function RSSAJumpAggregation(nj::Int, njt::T, et::T, crs::Vector{T}, sr::T,
     # a bracket data structure is needed for updating species populations
     bd = (bracket_data === nothing) ? BracketData{T, eltype(U)}() : bracket_data
 
-    # matrix to store bracketing interval for species and the relative interval width
-    # first row is Xlow, second is Xhigh
-    cs_bnds = Matrix{eltype(U)}(undef, 2, length(u))
-    ulow = @view cs_bnds[1, :]
-    uhigh = @view cs_bnds[2, :]
+    # current bounds on solution
+    ulow = similar(u)
+    uhigh = similar(u)
 
     affecttype = F2 <: Tuple ? F2 : Any
-    RSSAJumpAggregation{T, eltype(U), S, F1, affecttype, RNG, typeof(vtoj_map),
-                        typeof(jtov_map), typeof(bd), typeof(ulow)}(nj, nj, njt, et,
-                                                                    crl_bnds, crh_bnds, sr,
-                                                                    cs_bnds, maj, rs,
-                                                                    affs!, sps, rng,
-                                                                    vtoj_map, jtov_map, bd,
-                                                                    ulow, uhigh)
+    RSSAJumpAggregation{T, S, F1, affecttype, RNG, typeof(vtoj_map),
+                        typeof(jtov_map), typeof(bd), U}(nj, nj, njt, et, crl_bnds,
+                                                         crh_bnds, sr, maj, rs, affs!, sps,
+                                                         rng, vtoj_map, jtov_map, bd, ulow,
+                                                         uhigh)
 end
 
 ############################# Required Functions ##############################
@@ -149,7 +144,7 @@ Update rates
 """
 @inline function update_rates!(p::RSSAJumpAggregation, u, params, t)
     # update bracketing intervals
-    ubnds = p.cur_u_bnds
+    @unpack ulow, uhigh = p
     sum_rate = p.sum_rate
     crhigh = p.cur_rate_high
 
@@ -157,9 +152,9 @@ Update rates
         uval = u[uidx]
 
         # if new u value is outside the bracketing interval
-        if uval == zero(uval) || uval < ubnds[1, uidx] || uval > ubnds[2, uidx]
+        if uval == zero(uval) || uval < ulow[uidx] || uval > uhigh[uidx]
             # update u bracketing interval
-            ubnds[1, uidx], ubnds[2, uidx] = get_spec_brackets(p.bracket_data, uidx, uval)
+            ulow[uidx], uhigh[uidx] = get_spec_brackets(p.bracket_data, uidx, uval)
 
             # for each dependent jump, update jump rate brackets
             for jidx in p.vartojumps_map[uidx]

--- a/src/aggregators/rssacr.jl
+++ b/src/aggregators/rssacr.jl
@@ -81,8 +81,8 @@ function RSSACRJumpAggregation(nj::Int, njt::F, et::F, crs::Vector{F}, sum_rate:
 
     affecttype = F2 <: Tuple ? F2 : Any
     RSSACRJumpAggregation{typeof(njt), S, F1, affecttype, RNG, U, typeof(vtoj_map),
-                          typeof(jtov_map), typeof(bd), typeof(rt), typeof(ratetogroup)}(
-                                               nj, nj, njt, et, crl_bnds, crh_bnds,
+                          typeof(jtov_map), typeof(bd), typeof(rt),
+                          typeof(ratetogroup)}(nj, nj, njt, et, crl_bnds, crh_bnds,
                                                sum_rate, maj, rs, affs!, sps, rng, vtoj_map,
                                                jtov_map, bd, ulow, uhigh, minrate, maxrate,
                                                rt, ratetogroup)

--- a/test/allocations.jl
+++ b/test/allocations.jl
@@ -54,7 +54,7 @@ let
     end
 
     function makeprob(; T = 100.0, alg = Direct(), save_positions = (false, false),
-                        graphkwargs = (;))
+                      graphkwargs = (;))
         r1(u, p, t) = rate(p[1], u[1], u[2], p[2]) * u[1]
         r2(u, p, t) = rate(p[1], u[2], u[1], p[2]) * u[2]
         r3(u, p, t) = p[3] * u[1]
@@ -88,12 +88,12 @@ let
         return jprob
     end
 
-    idxs1 = [1,2,3,4]
-    idxs2 = [1,2,4,5,6]
+    idxs1 = [1, 2, 3, 4]
+    idxs2 = [1, 2, 4, 5, 6]
     idxs = collect(1:6)
     dep_graph = [copy(idxs1), copy(idxs2), copy(idxs1), copy(idxs2), copy(idxs), copy(idxs)]
     vartojumps_map = [copy(idxs1), copy(idxs2)]
-    jumptovars_map = [[1], [2], [1], [2], [1,2], [1,2]]
+    jumptovars_map = [[1], [2], [1], [2], [1, 2], [1, 2]]
     graphkwargs = (; dep_graph, vartojumps_map, jumptovars_map)
 
     @testset "Allocations for $agg" for agg in JumpProcesses.JUMP_AGGREGATORS

--- a/test/extinction_test.jl
+++ b/test/extinction_test.jl
@@ -1,4 +1,4 @@
-using DiffEqBase, JumpProcesses, StaticArrays
+using JumpProcesses, StaticArrays
 using Test
 using StableRNGs
 rng = StableRNG(12345)


### PR DESCRIPTION
Closes https://github.com/SciML/JumpProcesses.jl/issues/317

Adds allocations test for all non-spatial aggregators to ensure memory use is independent of the number of time-steps when saving is disabled.