### PR TITLE
Added ExtendedJumpArray dispatch for ODE_DEFAULT_NORM

### DIFF
--- a/src/extended_jump_array.jl
+++ b/src/extended_jump_array.jl
@@ -95,6 +95,11 @@ function Base.similar(A::ExtendedJumpArray, ::Type{S},
     ExtendedJumpArray(similar(A.u, S), similar(A.jump_u, S))
 end
 
+# ODE norm to prevent type-unstable fallback
+@inline function DiffEqBase.ODE_DEFAULT_NORM(u::ExtendedJumpArray, t)
+    Base.FastMath.sqrt_fast(real(sum(abs2, u)) / max(length(u), 1))
+end
+
 # Stiff ODE solver
 function ArrayInterface.zeromatrix(A::ExtendedJumpArray)
     u = [vec(A.u); vec(A.jump_u)]

--- a/test/extended_jump_array.jl
+++ b/test/extended_jump_array.jl
@@ -18,4 +18,4 @@ new_norm = DiffEqBase.ODE_DEFAULT_NORM(rand_array, 0.0)
 # Check that we no longer allocate. Run inside function so @allocated works properly
 norm_check_alloc(jump_array, t) = @allocated DiffEqBase.ODE_DEFAULT_NORM(jump_array, t)
 norm_check_alloc(rand_array, 0.0);
-@test 0 == @allocated norm_check_alloc(rand_array, 0.0)
+@test 0 == norm_check_alloc(rand_array, 0.0)

--- a/test/extended_jump_array.jl
+++ b/test/extended_jump_array.jl
@@ -4,14 +4,19 @@ using StableRNGs
 rng = StableRNG(123)
 
 # Check that the new broadcast norm gives the same result as the old one
-rand_array = ExtendedJumpArray{Float64, 1, Vector{Float64}, Vector{Float64}}(rand(rng, 5), rand(rng, 2))
-old_norm = Base.FastMath.sqrt_fast(DiffEqBase.UNITLESS_ABS2(rand_array) / max(DiffEqBase.recursive_length(rand_array), 1))
+rand_array = ExtendedJumpArray{Float64, 1, Vector{Float64}, Vector{Float64}}(rand(rng, 5),
+                                                                             rand(rng, 2))
+old_norm = Base.FastMath.sqrt_fast(DiffEqBase.UNITLESS_ABS2(rand_array) /
+                                   max(DiffEqBase.recursive_length(rand_array), 1))
 new_norm = DiffEqBase.ODE_DEFAULT_NORM(rand_array, 0.0)
 @test old_norm ≈ new_norm
 
 # Check for an ExtendedJumpArray where the types differ (Float64/Int64)
-rand_array = ExtendedJumpArray{Float64, 1, Vector{Float64}, Vector{Int64}}(rand(rng, 5), rand(rng, 1:1000, 2))
-old_norm = Base.FastMath.sqrt_fast(DiffEqBase.UNITLESS_ABS2(rand_array) / max(DiffEqBase.recursive_length(rand_array), 1))
+rand_array = ExtendedJumpArray{Float64, 1, Vector{Float64}, Vector{Int64}}(rand(rng, 5),
+                                                                           rand(rng, 1:1000,
+                                                                                2))
+old_norm = Base.FastMath.sqrt_fast(DiffEqBase.UNITLESS_ABS2(rand_array) /
+                                   max(DiffEqBase.recursive_length(rand_array), 1))
 new_norm = DiffEqBase.ODE_DEFAULT_NORM(rand_array, 0.0)
 @test old_norm ≈ new_norm
 

--- a/test/extended_jump_array.jl
+++ b/test/extended_jump_array.jl
@@ -1,0 +1,21 @@
+using Test, JumpProcesses, DiffEqBase
+using StableRNGs
+
+rng = StableRNG(123)
+
+# Check that the new broadcast norm gives the same result as the old one
+rand_array = ExtendedJumpArray{Float64, 1, Vector{Float64}, Vector{Float64}}(rand(rng, 5), rand(rng, 2))
+old_norm = Base.FastMath.sqrt_fast(DiffEqBase.UNITLESS_ABS2(rand_array) / max(DiffEqBase.recursive_length(rand_array), 1))
+new_norm = DiffEqBase.ODE_DEFAULT_NORM(rand_array, 0.0)
+@test old_norm ≈ new_norm
+
+# Check for an ExtendedJumpArray where the types differ (Float64/Int64)
+rand_array = ExtendedJumpArray{Float64, 1, Vector{Float64}, Vector{Int64}}(rand(rng, 5), rand(rng, 1:1000, 2))
+old_norm = Base.FastMath.sqrt_fast(DiffEqBase.UNITLESS_ABS2(rand_array) / max(DiffEqBase.recursive_length(rand_array), 1))
+new_norm = DiffEqBase.ODE_DEFAULT_NORM(rand_array, 0.0)
+@test old_norm ≈ new_norm
+
+# Check that we no longer allocate. Run inside function so @allocated works properly
+norm_check_alloc(jump_array, t) = @allocated DiffEqBase.ODE_DEFAULT_NORM(jump_array, t)
+norm_check_alloc(rand_array, 0.0);
+@test 0 == @allocated norm_check_alloc(rand_array, 0.0)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,6 +4,7 @@ using JumpProcesses, DiffEqBase, SafeTestsets
 @time begin
     @time @safetestset "Constant Rate Tests" begin include("constant_rate.jl") end
     @time @safetestset "Variable Rate Tests" begin include("variable_rate.jl") end
+    @time @safetestset "ExtendedJumpArray Tests" begin include("extended_jump_array.jl") end
     @time @safetestset "FunctionWrapper Tests" begin include("functionwrappers.jl") end
     @time @safetestset "Monte Carlo Tests" begin include("monte_carlo_test.jl") end
     @time @safetestset "Split Coupled Tests" begin include("splitcoupled.jl") end


### PR DESCRIPTION
This change reduces the number of allocations (to zero!) required to take the norm of an ExtendedJumpArray. Previously, ODE_DEFAULT_NORM fell back to a default, allocating implementation.

I also added tests to check that this norm definition is equivalent to the old one, using (stable) random ExtendedJumpArrays. There's also a test that checks that the new norm dispatch is not allocating.

This should close SciML/DifferentialEquations.jl#969