### PR TITLE
Refactor internal functions in spatial SSAs.

### DIFF
--- a/src/spatial/directcrdirect.jl
+++ b/src/spatial/directcrdirect.jl
@@ -106,7 +106,7 @@ end
 # set up a new simulation and calculate the first jump / jump time
 function initialize!(p::DirectCRDirectJumpAggregation, integrator, u, params, t)
     p.end_time = integrator.sol.prob.tspan[2]
-    fill_rates_and_get_times!(p, u, t)
+    fill_rates_and_get_times!(p, integrator, t)
     generate_jumps!(p, integrator, params, u, t)
     nothing
 end
@@ -127,7 +127,7 @@ function execute_jumps!(p::DirectCRDirectJumpAggregation, integrator, u, params,
     update_state!(p, integrator)
 
     # update current jump rates and times
-    update_dependent_rates_and_firing_times!(p, integrator.u, t)
+    update_dependent_rates_and_firing_times!(p, integrator, t)
     nothing
 end
 
@@ -137,8 +137,9 @@ end
 
 reset all stucts, reevaluate all rates, repopulate the priority table
 """
-function fill_rates_and_get_times!(aggregation::DirectCRDirectJumpAggregation, u, t)
+function fill_rates_and_get_times!(aggregation::DirectCRDirectJumpAggregation, integrator, t)
     @unpack spatial_system, rx_rates, hop_rates, site_rates, rt = aggregation
+    u = integrator.u
 
     reset!(rx_rates)
     reset!(hop_rates)
@@ -148,7 +149,7 @@ function fill_rates_and_get_times!(aggregation::DirectCRDirectJumpAggregation, u
     species = 1:(aggregation.numspecies)
 
     for site in 1:num_sites(spatial_system)
-        update_rx_rates!(rx_rates, rxs, u, site)
+        update_rx_rates!(rx_rates, rxs, integrator, site)
         update_hop_rates!(hop_rates, species, u, site, spatial_system)
         site_rates[site] = total_site_rate(rx_rates, hop_rates, site)
     end
@@ -161,17 +162,18 @@ function fill_rates_and_get_times!(aggregation::DirectCRDirectJumpAggregation, u
 end
 
 """
-    update_dependent_rates_and_firing_times!(p, u, t)
+    update_dependent_rates_and_firing_times!(p, integrator, t)
 
 recalculate jump rates for jumps that depend on the just executed jump (p.prev_jump)
 """
-function update_dependent_rates_and_firing_times!(p::DirectCRDirectJumpAggregation, u, t)
+function update_dependent_rates_and_firing_times!(p::DirectCRDirectJumpAggregation, integrator, t)
+    u = integrator.u
     site_rates = p.site_rates
     jump = p.prev_jump
     if is_hop(p, jump)
         source_site = jump.src
         target_site = jump.dst
-        update_rates_after_hop!(p, u, source_site, target_site, jump.jidx)
+        update_rates_after_hop!(p, integrator, source_site, target_site, jump.jidx)
 
         # update site rates
         oldrate = site_rates[source_site]
@@ -183,7 +185,7 @@ function update_dependent_rates_and_firing_times!(p::DirectCRDirectJumpAggregati
         update!(p.rt, target_site, oldrate, site_rates[target_site])
     else
         site = jump.src
-        update_rates_after_reaction!(p, u, site, reaction_id_from_jump(p, jump))
+        update_rates_after_reaction!(p, integrator, site, reaction_id_from_jump(p, jump))
 
         # update site rates
         oldrate = site_rates[site]

--- a/src/spatial/directcrdirect.jl
+++ b/src/spatial/directcrdirect.jl
@@ -16,8 +16,8 @@ mutable struct DirectCRDirectJumpAggregation{T, S, F1, F2, RNG, J, RX, HOP, DEPG
     rx_rates::RX
     hop_rates::HOP
     site_rates::Vector{T}
-    rates::F1 #rates for constant-rate jumps
-    affects!::F2 #affects! function determines the effect of constant-rate jumps
+    rates::F1 # legacy, not used
+    affects!::F2 # legacy, not used
     save_positions::Tuple{Bool, Bool}
     rng::RNG
     dep_gr::DEPGR #dep graph is same for each site

--- a/src/spatial/nsm.jl
+++ b/src/spatial/nsm.jl
@@ -12,8 +12,8 @@ mutable struct NSMJumpAggregation{T, S, F1, F2, RNG, J, RX, HOP, DEPGR, VJMAP, J
     end_time::T
     rx_rates::RX
     hop_rates::HOP
-    rates::F1 #rates for constant-rate jumps
-    affects!::F2 #affects! function determines the effect of constant-rate jumps
+    rates::F1 # legacy, not used
+    affects!::F2 # legacy, not used
     save_positions::Tuple{Bool, Bool}
     rng::RNG
     dep_gr::DEPGR #dep graph is same for each site

--- a/src/spatial/nsm.jl
+++ b/src/spatial/nsm.jl
@@ -94,7 +94,7 @@ end
 # set up a new simulation and calculate the first jump / jump time
 function initialize!(p::NSMJumpAggregation, integrator, u, params, t)
     p.end_time = integrator.sol.prob.tspan[2]
-    fill_rates_and_get_times!(p, u, t)
+    fill_rates_and_get_times!(p, integrator, t)
     generate_jumps!(p, integrator, params, u, t)
     nothing
 end
@@ -113,7 +113,7 @@ function execute_jumps!(p::NSMJumpAggregation, integrator, u, params, t, affects
     update_state!(p, integrator)
 
     # update current jump rates and times
-    update_dependent_rates_and_firing_times!(p, integrator.u, t)
+    update_dependent_rates_and_firing_times!(p, integrator, t)
     nothing
 end
 
@@ -123,8 +123,9 @@ end
 
 reset all stucts, reevaluate all rates, recalculate tentative site firing times, and reinit the priority queue
 """
-function fill_rates_and_get_times!(aggregation::NSMJumpAggregation, u, t)
+function fill_rates_and_get_times!(aggregation::NSMJumpAggregation, integrator, t)
     @unpack spatial_system, rx_rates, hop_rates, rng = aggregation
+    u = integrator.u
 
     reset!(rx_rates)
     reset!(hop_rates)
@@ -135,7 +136,7 @@ function fill_rates_and_get_times!(aggregation::NSMJumpAggregation, u, t)
 
     pqdata = Vector{typeof(t)}(undef, num_nodes)
     @inbounds for site in 1:num_nodes
-        update_rx_rates!(rx_rates, rxs, u, site)
+        update_rx_rates!(rx_rates, rxs, integrator, site)
         update_hop_rates!(hop_rates, species, u, site, spatial_system)
         pqdata[site] = t + randexp(rng) / (total_site_rate(rx_rates, hop_rates, site))
     end
@@ -145,21 +146,22 @@ function fill_rates_and_get_times!(aggregation::NSMJumpAggregation, u, t)
 end
 
 """
-    update_dependent_rates_and_firing_times!(p, u, t)
+    update_dependent_rates_and_firing_times!(p, integrator, t)
 
 recalculate jump rates for jumps that depend on the just executed jump (p.prev_jump)
 """
-function update_dependent_rates_and_firing_times!(p::NSMJumpAggregation, u, t)
+function update_dependent_rates_and_firing_times!(p::NSMJumpAggregation, integrator, t)
+    u = integrator.u
     jump = p.prev_jump
     if is_hop(p, jump)
         source_site = jump.src
         target_site = jump.dst
-        update_rates_after_hop!(p, u, source_site, target_site, jump.jidx)
+        update_rates_after_hop!(p, integrator, source_site, target_site, jump.jidx)
         update_site_time!(p, source_site, t)
         update_site_time!(p, target_site, t)
     else
         site = jump.src
-        update_rates_after_reaction!(p, u, site, reaction_id_from_jump(p, jump))
+        update_rates_after_reaction!(p, integrator, site, reaction_id_from_jump(p, jump))
         update_site_time!(p, site, t)
     end
     nothing

--- a/src/spatial/reaction_rates.jl
+++ b/src/spatial/reaction_rates.jl
@@ -57,17 +57,8 @@ function update_rx_rates!(rx_rates::RxRates{F, M}, rxs, integrator,
     u = integrator.u
     ma_jumps = rx_rates.ma_jumps
     @inbounds for rx in rxs
-        set_rx_rate_at_site!(rx_rates, site, rx,
-                             evalrxrate((@view u[:, site]), rx, ma_jumps))
-    end
-end
-
-function update_rx_rates!(rx_rates::RxRates{F, M}, rxs, integrator,
-                          site) where {F, M <: SpatialMassActionJump}
-    u = integrator.u
-    ma_jumps = rx_rates.ma_jumps
-    @inbounds for rx in rxs
-        set_rx_rate_at_site!(rx_rates, site, rx, evalrxrate(u, rx, ma_jumps, site))
+        rate = eval_massaction_rate(u, rx, ma_jumps, site)
+        set_rx_rate_at_site!(rx_rates, site, rx, rate)
     end
 end
 
@@ -93,3 +84,6 @@ function Base.show(io::IO, ::MIME"text/plain", rx_rates::RxRates)
     num_rxs, num_sites = size(rx_rates.rates)
     println(io, "RxRates with $num_rxs reactions and $num_sites sites")
 end
+
+eval_massaction_rate(u, rx, ma_jumps::M, site) where {M <: SpatialMassActionJump} = evalrxrate(u, rx, ma_jumps, site)
+eval_massaction_rate(u, rx, ma_jumps::M, site) where {M <: MassActionJump} = evalrxrate((@view u[:, site]), rx, ma_jumps)

--- a/src/spatial/reaction_rates.jl
+++ b/src/spatial/reaction_rates.jl
@@ -53,7 +53,7 @@ end
 update rates of all reactions in rxs at site
 """
 function update_rx_rates!(rx_rates::RxRates{F, M}, rxs, integrator,
-                          site) where {F, M <: MassActionJump}
+                          site) where {F, M <: AbstractMassActionJump}
     u = integrator.u
     ma_jumps = rx_rates.ma_jumps
     @inbounds for rx in rxs

--- a/src/spatial/reaction_rates.jl
+++ b/src/spatial/reaction_rates.jl
@@ -52,8 +52,9 @@ end
 
 update rates of all reactions in rxs at site
 """
-function update_rx_rates!(rx_rates::RxRates{F, M}, rxs, u,
+function update_rx_rates!(rx_rates::RxRates{F, M}, rxs, integrator,
                           site) where {F, M <: MassActionJump}
+    u = integrator.u
     ma_jumps = rx_rates.ma_jumps
     @inbounds for rx in rxs
         set_rx_rate_at_site!(rx_rates, site, rx,
@@ -61,8 +62,9 @@ function update_rx_rates!(rx_rates::RxRates{F, M}, rxs, u,
     end
 end
 
-function update_rx_rates!(rx_rates::RxRates{F, M}, rxs, u,
+function update_rx_rates!(rx_rates::RxRates{F, M}, rxs, integrator,
                           site) where {F, M <: SpatialMassActionJump}
+    u = integrator.u
     ma_jumps = rx_rates.ma_jumps
     @inbounds for rx in rxs
         set_rx_rate_at_site!(rx_rates, site, rx, evalrxrate(u, rx, ma_jumps, site))

--- a/src/spatial/spatial_massaction_jump.jl
+++ b/src/spatial/spatial_massaction_jump.jl
@@ -89,6 +89,9 @@ function SpatialMassActionJump(ma_jumps::MassActionJump{T, S, U, V}; scale_rates
                           scale_rates = scale_rates, useiszero = useiszero, nocopy = nocopy)
 end
 
+function SpatialMassActionJump(nothing)
+    SpatialMassActionJump([], [], [])
+end
 ##############################################
 
 function get_num_majumps(smaj::SpatialMassActionJump{Nothing, Nothing, S, U, V}) where

--- a/src/spatial/spatial_massaction_jump.jl
+++ b/src/spatial/spatial_massaction_jump.jl
@@ -89,9 +89,6 @@ function SpatialMassActionJump(ma_jumps::MassActionJump{T, S, U, V}; scale_rates
                           scale_rates = scale_rates, useiszero = useiszero, nocopy = nocopy)
 end
 
-function SpatialMassActionJump(nothing)
-    SpatialMassActionJump([], [], [])
-end
 ##############################################
 
 function get_num_majumps(smaj::SpatialMassActionJump{Nothing, Nothing, S, U, V}) where

--- a/src/spatial/utils.jl
+++ b/src/spatial/utils.jl
@@ -43,16 +43,18 @@ function total_site_rate(rx_rates::RxRates, hop_rates::AbstractHopRates, site)
     total_site_hop_rate(hop_rates, site) + total_site_rx_rate(rx_rates, site)
 end
 
-function update_rates_after_reaction!(p, u, site, reaction_id)
-    update_rx_rates!(p.rx_rates, p.dep_gr[reaction_id], u, site)
+function update_rates_after_reaction!(p, integrator, site, reaction_id)
+    u = integrator.u
+    update_rx_rates!(p.rx_rates, p.dep_gr[reaction_id], integrator, site)
     update_hop_rates!(p.hop_rates, p.jumptovars_map[reaction_id], u, site, p.spatial_system)
 end
 
-function update_rates_after_hop!(p, u, source_site, target_site, species)
-    update_rx_rates!(p.rx_rates, p.vartojumps_map[species], u, source_site)
+function update_rates_after_hop!(p, integrator, source_site, target_site, species)
+    u = integrator.u
+    update_rx_rates!(p.rx_rates, p.vartojumps_map[species], integrator, source_site)
     update_hop_rate!(p.hop_rates, species, u, source_site, p.spatial_system)
 
-    update_rx_rates!(p.rx_rates, p.vartojumps_map[species], u, target_site)
+    update_rx_rates!(p.rx_rates, p.vartojumps_map[species], integrator, target_site)
     update_hop_rate!(p.hop_rates, species, u, target_site, p.spatial_system)
 end
 

--- a/test/spatial/reaction_rates.jl
+++ b/test/spatial/reaction_rates.jl
@@ -9,8 +9,10 @@ const JP = JumpProcesses
 # sample_rx_at_site
 
 # Dummy integrator to test update_rx_rates!
-struct DummyIntegrator{S}
-    u::S
+struct DummyIntegrator{U,P,T}
+    u::U # state
+    p::P # parameters
+    t::T # time
 end
 
 io = IOBuffer()

--- a/test/spatial/reaction_rates.jl
+++ b/test/spatial/reaction_rates.jl
@@ -6,8 +6,12 @@ const JP = JumpProcesses
 # reset!
 # total_site_rx_rate
 # update_rx_rates!
-# update_rx_rates!
 # sample_rx_at_site
+
+# Dummy integrator to test update_rx_rates!
+struct DummyIntegrator{S}
+    u::S
+end
 
 io = IOBuffer()
 # setup of A + B <--> C
@@ -22,6 +26,7 @@ num_rxs = length(rates)
 ma_jumps = MassActionJump(rates, reactstoch, netstoch)
 spatial_ma_jumps = SpatialMassActionJump(rates, reactstoch, netstoch)
 u = ones(Int, num_species, num_nodes)
+integrator = DummyIntegrator(u)
 rng = StableRNG(12345)
 
 # Tests for RxRates
@@ -30,7 +35,7 @@ for rx_rates in rx_rates_list
     @test JP.num_rxs(rx_rates) == length(rates)
     show(io, "text/plain", rx_rates)
     for site in 1:num_nodes
-        JP.update_rx_rates!(rx_rates, 1:num_rxs, u, site)
+        JP.update_rx_rates!(rx_rates, 1:num_rxs, integrator, site)
         @test JP.total_site_rx_rate(rx_rates, site) == 1.1
         rx_props = [JP.evalrxrate(u[:, site], rx, ma_jumps) for rx in 1:num_rxs]
         rx_probs = rx_props / sum(rx_props)

--- a/test/spatial/reaction_rates.jl
+++ b/test/spatial/reaction_rates.jl
@@ -28,7 +28,7 @@ num_rxs = length(rates)
 ma_jumps = MassActionJump(rates, reactstoch, netstoch)
 spatial_ma_jumps = SpatialMassActionJump(rates, reactstoch, netstoch)
 u = ones(Int, num_species, num_nodes)
-integrator = DummyIntegrator(u)
+integrator = DummyIntegrator(u,nothing,nothing)
 rng = StableRNG(12345)
 
 # Tests for RxRates


### PR DESCRIPTION
This is a pure refactoring PR to make adding support for spatial constant rate jumps easier.

- Pass `integrator` around internally.
- Refactor `update_rx_rates!` in `reaction_rates.jl`.