### PR TITLE
Improve spatial tests

### DIFF
--- a/test/spatial/ABC.jl
+++ b/test/spatial/ABC.jl
@@ -1,6 +1,8 @@
 using JumpProcesses, DiffEqBase
 # using BenchmarkTools
 using Test, Graphs
+using StableRNGs
+rng = StableRNG(12345)
 
 Nsims = 100
 reltol = 0.05
@@ -50,14 +52,14 @@ grids = [CartesianGridRej(dims), Graphs.grid(dims)]
 jump_problems = JumpProblem[JumpProblem(prob, NSM(), majumps,
                                         hopping_constants = hopping_constants,
                                         spatial_system = grid,
-                                        save_positions = (false, false)) for grid in grids]
+                                        save_positions = (false, false), rng = rng) for grid in grids]
 push!(jump_problems,
       JumpProblem(prob, DirectCRDirect(), majumps, hopping_constants = hopping_constants,
-                  spatial_system = grids[1], save_positions = (false, false)))
+                  spatial_system = grids[1], save_positions = (false, false), rng = rng))
 # setup flattenned jump prob
 push!(jump_problems,
       JumpProblem(prob, NRM(), majumps, hopping_constants = hopping_constants,
-                  spatial_system = grids[1], save_positions = (false, false)))
+                  spatial_system = grids[1], save_positions = (false, false), rng = rng))
 # test
 for spatial_jump_prob in jump_problems
     solution = solve(spatial_jump_prob, SSAStepper())

--- a/test/spatial/spatial_majump.jl
+++ b/test/spatial/spatial_majump.jl
@@ -1,8 +1,10 @@
 using JumpProcesses, DiffEqBase, OrdinaryDiffEq
 using Test, Graphs, LinearAlgebra
+using StableRNGs
+rng = StableRNG(12345)
 
 reltol = 0.05
-Nsims = 10^4
+Nsims = 10^3
 
 dim = 1
 linear_size = 5
@@ -57,19 +59,19 @@ non_uniform_majumps = [non_uniform_majumps_1, non_uniform_majumps_2, non_uniform
 uniform_jump_problems = JumpProblem[JumpProblem(prob, NSM(), majump,
                                                 hopping_constants = hopping_constants,
                                                 spatial_system = grid,
-                                                save_positions = (false, false))
+                                                save_positions = (false, false), rng = rng)
                                     for majump in uniform_majumps]
 # flattenned
 append!(uniform_jump_problems,
         JumpProblem[JumpProblem(prob, NRM(), majump, hopping_constants = hopping_constants,
-                                spatial_system = grid, save_positions = (false, false))
+                                spatial_system = grid, save_positions = (false, false), rng = rng)
                     for majump in uniform_majumps])
 
 # non-uniform
 non_uniform_jump_problems = JumpProblem[JumpProblem(prob, NSM(), majump,
                                                     hopping_constants = hopping_constants,
                                                     spatial_system = grid,
-                                                    save_positions = (false, false))
+                                                    save_positions = (false, false), rng = rng)
                                         for majump in non_uniform_majumps]
 
 # testing


### PR DESCRIPTION
Add stable RNGs to the spatial integration tests and reduce number of simulations. This reduces the runtime of spatial tests by over 50%.