### PR TITLE
remove support for unsuported julia versions

### DIFF
--- a/src/JumpProcesses.jl
+++ b/src/JumpProcesses.jl
@@ -27,17 +27,8 @@ abstract type AbstractSSAIntegrator{Alg, IIP, U, T} <:
               DiffEqBase.DEIntegrator{Alg, IIP, U, T} end
 
 import Base.Threads
-@static if VERSION < v"1.3"
-    seed_multiplier() = Threads.threadid()
-else
-    seed_multiplier() = 1
-end
 
-@static if VERSION >= v"1.7.0"
-    const DEFAULT_RNG = Random.default_rng()
-else
-    const DEFAULT_RNG = Xorshifts.Xoroshiro128Star(rand(UInt64))
-end
+const DEFAULT_RNG = Random.default_rng()
 
 include("jumps.jl")
 include("massaction_rates.jl")

--- a/src/SSA_stepper.jl
+++ b/src/SSA_stepper.jl
@@ -166,7 +166,7 @@ function DiffEqBase.__init(jump_prob::JumpProblem,
     else
         cb = deepcopy(jump_prob.jump_callback.discrete_callbacks[end])
         if seed === nothing
-            Random.seed!(cb.condition.rng, seed_multiplier() * rand(UInt64))
+            Random.seed!(cb.condition.rng, rand(UInt64))
         else
             Random.seed!(cb.condition.rng, seed)
         end

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -39,7 +39,7 @@ function resetted_jump_problem(_jump_prob, seed)
     if !isempty(jump_prob.jump_callback.discrete_callbacks)
         if seed === nothing
             Random.seed!(jump_prob.jump_callback.discrete_callbacks[1].condition.rng,
-                seed_multiplier() * rand(UInt64))
+                rand(UInt64))
         else
             Random.seed!(jump_prob.jump_callback.discrete_callbacks[1].condition.rng, seed)
         end


### PR DESCRIPTION
Since the Project.toml declares julia 1.10 as the lower bound, we don't need the ifs for older versions.