### PR TITLE
periodic callback and tstop aliasing fixes

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -28,7 +28,7 @@ FastBroadcast = "7034ab61-46d4-4ed7-9d0f-46aef9175898"
 [compat]
 ArrayInterface = "7.9"
 DataStructures = "0.18"
-DiffEqBase = "6.148"
+DiffEqBase = "6.154"
 DocStringExtensions = "0.9"
 FastBroadcast = "0.3"
 FunctionWrappers = "1.1"

--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@
 
 <!-- [![Coverage Status](https://coveralls.io/repos/github/SciML/JumpProcesses.jl/badge.svg?branch=master)](https://coveralls.io/github/SciML/JumpProcesses.jl?branch=master)
 [![codecov](https://codecov.io/gh/SciML/JumpProcesses.jl/branch/master/graph/badge.svg)](https://codecov.io/gh/SciML/JumpProcesses.jl) -->
-
 [![Build Status](https://github.com/SciML/JumpProcesses.jl/workflows/CI/badge.svg)](https://github.com/SciML/JumpProcesses.jl/actions?query=workflow%3ACI)
 [![ColPrac: Contributor's Guide on Collaborative Practices for Community Packages](https://img.shields.io/badge/ColPrac-Contributor%27s%20Guide-blueviolet)](https://github.com/SciML/ColPrac)
 [![SciML Code Style](https://img.shields.io/static/v1?label=code%20style&message=SciML&color=9558b2&labelColor=389826)](https://github.com/SciML/SciMLStyle)

--- a/src/JumpProcesses.jl
+++ b/src/JumpProcesses.jl
@@ -10,7 +10,8 @@ using Graphs
 using SciMLBase: SciMLBase, isdenseplot
 using Base.FastMath: add_fast
 
-import DiffEqBase: DiscreteCallback, init, solve, solve!, plot_indices, initialize!
+import DiffEqBase: DiscreteCallback, init, solve, solve!, plot_indices, initialize!,
+                   get_tstops, get_tstops_array, get_max_tstops, hasiter
 import Base: size, getindex, setindex!, length, similar, show, merge!, merge
 import DataStructures: update!
 import Graphs: neighbors, outdegree

--- a/src/JumpProcesses.jl
+++ b/src/JumpProcesses.jl
@@ -11,7 +11,7 @@ using SciMLBase: SciMLBase, isdenseplot
 using Base.FastMath: add_fast
 
 import DiffEqBase: DiscreteCallback, init, solve, solve!, plot_indices, initialize!,
-                   get_tstops, get_tstops_array, get_max_tstops, hasiter
+                   get_tstops, get_tstops_array, get_tstops_max
 import Base: size, getindex, setindex!, length, similar, show, merge!, merge
 import DataStructures: update!
 import Graphs: neighbors, outdegree

--- a/src/SSA_stepper.jl
+++ b/src/SSA_stepper.jl
@@ -110,7 +110,7 @@ DiffEqBase.get_tstops_array(integrator::SSAIntegrator) = DiffEqBase.get_tstops(i
 
 # ODE integrators seem to add tf into tstops which SSAIntegrator does not do
 # so must account for it here
-function DiffEqBase.get_max_tstops(integrator::SSAIntegrator)
+function DiffEqBase.get_tstops_max(integrator::SSAIntegrator)
     tstops = DiffEqBase.get_tstops_array(integrator)
     tf = integrator.sol.prob.tspan[2]
     if !isempty(tstops)
@@ -119,9 +119,6 @@ function DiffEqBase.get_max_tstops(integrator::SSAIntegrator)
         return tf
     end
 end
-
-# no integrator.iter field
-DiffEqBase.hasiter(::SSAIntegrator) = false
 
 function DiffEqBase.u_modified!(integrator::SSAIntegrator, bool::Bool)
     integrator.u_modified = bool

--- a/src/SSA_stepper.jl
+++ b/src/SSA_stepper.jl
@@ -243,10 +243,9 @@ function DiffEqBase.add_tstop!(integrator::SSAIntegrator, tstop)
     if tstop > integrator.t
         future_tstops = @view integrator.tstops[(integrator.tstops_idx):end]
         insert_index = integrator.tstops_idx + searchsortedfirst(future_tstops, tstop) - 1
-        @show insert_index
         Base.insert!(integrator.tstops, insert_index, tstop)
     end
-    @show integrator.t,tstop,integrator.tstops
+    nothing
 end
 
 # The Jump aggregators should not register the next jump through add_tstop! for SSAIntegrator

--- a/src/SSA_stepper.jl
+++ b/src/SSA_stepper.jl
@@ -163,7 +163,6 @@ function DiffEqBase.__init(jump_prob::JumpProblem,
         tstops = nothing,
         alias_tstops = false,
         numsteps_hint = 100)
-
     if !(jump_prob.prob isa DiscreteProblem)
         error("SSAStepper only supports DiscreteProblems.")
     end
@@ -264,10 +263,10 @@ function DiffEqBase.add_tstop!(integrator::SSAIntegrator, tstop)
             tstops = integrator.tstops
         else
             integrator.copied_tstops = true
-            tstops = copy(integrator.tstops)
+            integrator.tstops = copy(integrator.tstops)
         end
 
-        Base.insert!(tstops, insert_index, tstop)
+        Base.insert!(integrator.tstops, insert_index, tstop)
     end
     nothing
 end

--- a/src/SSA_stepper.jl
+++ b/src/SSA_stepper.jl
@@ -261,10 +261,8 @@ function DiffEqBase.add_tstop!(integrator::SSAIntegrator, tstop)
         future_tstops = @view integrator.tstops[(integrator.tstops_idx):end]
         insert_index = integrator.tstops_idx + searchsortedfirst(future_tstops, tstop) - 1
 
-        # if aliasing or have already copied the user tstops array
-        if integrator.alias_tstops || integrator.copied_tstops
-            tstops = integrator.tstops
-        else
+        # if not aliasing and have not already copied the user tstops array
+        if !integrator.alias_tstops && !integrator.copied_tstops
             integrator.copied_tstops = true
             integrator.tstops = copy(integrator.tstops)
         end

--- a/src/SSA_stepper.jl
+++ b/src/SSA_stepper.jl
@@ -124,6 +124,12 @@ function DiffEqBase.solve!(integrator::SSAIntegrator)
     end
     integrator.t = end_time
 
+    # check callbacks one last time
+    if !(integrator.opts.callback.discrete_callbacks isa Tuple{})
+        DiffEqBase.apply_discrete_callback!(integrator,
+            integrator.opts.callback.discrete_callbacks...)
+    end
+
     if integrator.saveat !== nothing && !isempty(integrator.saveat)
         # Split to help prediction
         while integrator.cur_saveat <= length(integrator.saveat) &&
@@ -194,7 +200,7 @@ function DiffEqBase.__init(jump_prob::JumpProblem,
         stats = DiffEqBase.Stats(0),
         interp = DiffEqBase.ConstantInterpolation(t, u))
 
-    _saveat = (saveat isa Number) ? prob.tspan[1]:saveat:prob.tspan[2] : saveat
+    _saveat = (saveat isa Number) ? (prob.tspan[1]:saveat:prob.tspan[2]) : saveat
     if _saveat !== nothing && !isempty(_saveat) && _saveat[1] == prob.tspan[1]
         cur_saveat = 2
     else

--- a/src/SSA_stepper.jl
+++ b/src/SSA_stepper.jl
@@ -161,8 +161,11 @@ function DiffEqBase.__init(jump_prob::JumpProblem,
         saveat = nothing,
         callback = nothing,
         tstops = nothing,
-        alias_tstops = false,
         numsteps_hint = 100)
+
+    # hack until alias system is in place
+    alias_tstops = false
+
     if !(jump_prob.prob isa DiscreteProblem)
         error("SSAStepper only supports DiscreteProblems.")
     end

--- a/test/ssa_callback_test.jl
+++ b/test/ssa_callback_test.jl
@@ -183,4 +183,5 @@ let
     integ = init(jprob, SSAStepper(); callback = cb, tstops)
     solve!(integ)
     @test integ.tstops !== tstops
+    @test isempty(tstops)
 end

--- a/test/ssa_callback_test.jl
+++ b/test/ssa_callback_test.jl
@@ -167,14 +167,20 @@ let
     cb = PeriodicCallback(cbfun, 1.0)
     jprob = JumpProblem(dprob, crj; rng)
     tstops = Float64[]
-    sol = solve(jprob; callback = cb, tstops, alias_tstops = true)
-    @test sol[1, end] == 9
-    @test tstops == 1.0:9.0
-    empty!(tstops)
-    sol = solve(jprob; callback = cb, tstops, alias_tstops = false)
-    @test sol[1, end] == 9
-    @test isempty(tstops)
+    # tests for when aliasing system is in place
+    #sol = solve(jprob; callback = cb, tstops, alias_tstops = true) 
+    # @test sol[1, end] == 9
+    #@test tstops == 1.0:9.0    
+    # empty!(tstops)
+    # sol = solve(jprob; callback = cb, tstops, alias_tstops = false)
+    # @test sol[1, end] == 9
+    # @test isempty(tstops)
     sol = solve(jprob; callback = cb, tstops)
     @test sol[1, end] == 9
     @test isempty(tstops)
+
+    empty!(tstops)
+    integ = init(jprob, SSAStepper(); callback = cb, tstops)
+    solve!(integ)
+    @test integ.tstops !== tstops
 end


### PR DESCRIPTION
Closes https://github.com/SciML/JumpProcesses.jl/issues/417.
Closes https://github.com/SciML/JumpProcesses.jl/issues/442

This also adds an `alias_tstops` keyword to `solve` allowing the `tstop` vector to be aliased. By default it is `false`.

Should be good to go once
- https://github.com/SciML/DiffEqBase.jl/pull/1071 and a DiffEqBase release
- https://github.com/SciML/OrdinaryDiffEq.jl/pull/2377 and OrdinaryDiffEq release
- https://github.com/SciML/StochasticDiffEq.jl/pull/580 and StochasticDiffEq release
- https://github.com/SciML/Sundials.jl/pull/459 and Sundials release
- https://github.com/SciML/DiffEqCallbacks.jl/pull/229 and a DiffEqCallbacks release

