### PR TITLE
fix vrj reinitialization bug

### DIFF
--- a/src/solve.jl
+++ b/src/solve.jl
@@ -58,7 +58,8 @@ function resetted_jump_problem(_jump_prob, seed)
 
     if !isempty(jump_prob.variable_jumps)
         @assert jump_prob.prob.u0 isa ExtendedJumpArray
-        @. jump_prob.prob.u0.jump_u = -randexp(_jump_prob.rng, eltype(_jump_prob.prob.tspan))
+        @. jump_prob.prob.u0.jump_u = -randexp(
+            _jump_prob.rng, eltype(_jump_prob.prob.tspan))
     end
     jump_prob
 end

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -58,8 +58,8 @@ function resetted_jump_problem(_jump_prob, seed)
 
     if !isempty(jump_prob.variable_jumps)
         @assert jump_prob.prob.u0 isa ExtendedJumpArray
-        @. jump_prob.prob.u0.jump_u = -randexp(_jump_prob.rng,
-            eltype(_jump_prob.prob.tspan))
+        ttype = eltype(_jump_prob.prob.tspan)
+        @. jump_prob.prob.u0.jump_u = -randexp(_jump_prob.rng, ttype)
     end
     jump_prob
 end
@@ -71,6 +71,7 @@ function reset_jump_problem!(jump_prob, seed)
 
     if !isempty(jump_prob.variable_jumps)
         @assert jump_prob.prob.u0 isa ExtendedJumpArray
-        @. jump_prob.prob.u0.jump_u = -randexp(jump_prob.rng, eltype(jump_prob.prob.tspan))
+        ttype = eltype(jump_prob.prob.tspan)
+        @. jump_prob.prob.u0.jump_u = -randexp(jump_prob.rng, ttype)
     end
 end

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -58,7 +58,7 @@ function resetted_jump_problem(_jump_prob, seed)
 
     if !isempty(jump_prob.variable_jumps)
         @assert jump_prob.prob.u0 isa ExtendedJumpArray
-        jump_prob.prob.u0.jump_u .= -randexp.(_jump_prob.rng, eltype(_jump_prob.prob.tspan))
+        @. jump_prob.prob.u0.jump_u = -randexp(_jump_prob.rng, eltype(_jump_prob.prob.tspan))
     end
     jump_prob
 end
@@ -70,6 +70,6 @@ function reset_jump_problem!(jump_prob, seed)
 
     if !isempty(jump_prob.variable_jumps)
         @assert jump_prob.prob.u0 isa ExtendedJumpArray
-        jump_prob.prob.u0.jump_u .= -randexp.(jump_prob.rng, eltype(jump_prob.prob.tspan))
+        @. jump_prob.prob.u0.jump_u = -randexp(jump_prob.rng, eltype(jump_prob.prob.tspan))
     end
 end

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -58,8 +58,8 @@ function resetted_jump_problem(_jump_prob, seed)
 
     if !isempty(jump_prob.variable_jumps)
         @assert jump_prob.prob.u0 isa ExtendedJumpArray
-        @. jump_prob.prob.u0.jump_u = -randexp(
-            _jump_prob.rng, eltype(_jump_prob.prob.tspan))
+        @. jump_prob.prob.u0.jump_u = -randexp(_jump_prob.rng, 
+            eltype(_jump_prob.prob.tspan))
     end
     jump_prob
 end

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -58,7 +58,7 @@ function resetted_jump_problem(_jump_prob, seed)
 
     if !isempty(jump_prob.variable_jumps)
         @assert jump_prob.prob.u0 isa ExtendedJumpArray
-        @. jump_prob.prob.u0.jump_u = -randexp(_jump_prob.rng, 
+        @. jump_prob.prob.u0.jump_u = -randexp(_jump_prob.rng,
             eltype(_jump_prob.prob.tspan))
     end
     jump_prob

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -58,8 +58,8 @@ function resetted_jump_problem(_jump_prob, seed)
 
     if !isempty(jump_prob.variable_jumps)
         @assert jump_prob.prob.u0 isa ExtendedJumpArray
-        ttype = eltype(_jump_prob.prob.tspan)
-        @. jump_prob.prob.u0.jump_u = -randexp(_jump_prob.rng, ttype)
+        randexp!(_jump_prob.rng, jump_prob.prob.u0.jump_u)
+        jump_prob.prob.u0.jump_u .*= -1
     end
     jump_prob
 end
@@ -71,7 +71,7 @@ function reset_jump_problem!(jump_prob, seed)
 
     if !isempty(jump_prob.variable_jumps)
         @assert jump_prob.prob.u0 isa ExtendedJumpArray
-        ttype = eltype(jump_prob.prob.tspan)
-        @. jump_prob.prob.u0.jump_u = -randexp(jump_prob.rng, ttype)
+        randexp!(jump_prob.rng, jump_prob.prob.u0.jump_u)
+        jump_prob.prob.u0.jump_u .*= -1
     end
 end

--- a/test/variable_rate.jl
+++ b/test/variable_rate.jl
@@ -234,11 +234,11 @@ end
 let
     b = 2.0
     d = 1.0
-    n0 = 1 
+    n0 = 1
     tspan = (0.0, 4.0)
-    Nsims = 10    
+    Nsims = 10
     u0 = [n0]
-    p = [b,d]
+    p = [b, d]
 
     function ode_fxn(du, u, p, t)
         du .= 0
@@ -246,28 +246,25 @@ let
     end
     b_rate(u, p, t) = (u[1] * p[1])
     function birth!(integrator)
-        integrator.u[1] += 1 
+        integrator.u[1] += 1
         nothing
     end
     b_jump = VariableRateJump(b_rate, birth!)
-    
+
     d_rate(u, p, t) = (u[1] * p[2])
     function death!(integrator)
         integrator.u[1] -= 1
         nothing
     end
     d_jump = VariableRateJump(d_rate, death!)
-        
+
     ode_prob = ODEProblem(ode_fxn, u0, tspan, p)
     sjm_prob = JumpProblem(ode_prob, b_jump, d_jump; rng)
     u0old = copy(sjm_prob.prob.u0.jump_u)
-    dt = .1
-    tsave = range(tspan[1], tspan[2]; step = dt)
-    umean = zeros(length(tsave))
     for i in 1:Nsims
-        sol = solve(sjm_prob, Tsit5(); saveat = dt)
+        sol = solve(sjm_prob, Tsit5(); saveat = tspan[2])
         @test allunique(sjm_prob.prob.u0.jump_u)
         @test all(u0old != sjm_prob.prob.u0.jump_u)
         u0old .= sjm_prob.prob.u0.jump_u
-    end    
+    end
 end

--- a/test/variable_rate.jl
+++ b/test/variable_rate.jl
@@ -229,3 +229,45 @@ let
         solve(jprob, SSAStepper())
     end
 end
+
+# test u0 resets correctly
+let
+    b = 2.0
+    d = 1.0
+    n0 = 1 
+    tspan = (0.0, 4.0)
+    Nsims = 10    
+    u0 = [n0]
+    p = [b,d]
+
+    function ode_fxn(du, u, p, t)
+        du .= 0
+        nothing
+    end
+    b_rate(u, p, t) = (u[1] * p[1])
+    function birth!(integrator)
+        integrator.u[1] += 1 
+        nothing
+    end
+    b_jump = VariableRateJump(b_rate, birth!)
+    
+    d_rate(u, p, t) = (u[1] * p[2])
+    function death!(integrator)
+        integrator.u[1] -= 1
+        nothing
+    end
+    d_jump = VariableRateJump(d_rate, death!)
+        
+    ode_prob = ODEProblem(ode_fxn, u0, tspan, p)
+    sjm_prob = JumpProblem(ode_prob, b_jump, d_jump; rng)
+    u0old = copy(sjm_prob.prob.u0.jump_u)
+    dt = .1
+    tsave = range(tspan[1], tspan[2]; step = dt)
+    umean = zeros(length(tsave))
+    for i in 1:Nsims
+        sol = solve(sjm_prob, Tsit5(); saveat = dt)
+        @test allunique(sjm_prob.prob.u0.jump_u)
+        @test all(u0old != sjm_prob.prob.u0.jump_u)
+        u0old .= sjm_prob.prob.u0.jump_u
+    end    
+end

--- a/test/variable_rate.jl
+++ b/test/variable_rate.jl
@@ -261,9 +261,10 @@ let
 
     ode_prob = ODEProblem(ode_fxn, u0, tspan, p)
     sjm_prob = JumpProblem(ode_prob, b_jump, d_jump; rng)
+    @test allunique(sjm_prob.prob.u0.jump_u)
     u0old = copy(sjm_prob.prob.u0.jump_u)
     for i in 1:Nsims
-        sol = solve(sjm_prob, Tsit5(); saveat = tspan[2])
+        sol = solve(sjm_prob, Tsit5(); saveat = tspan[2])        
         @test allunique(sjm_prob.prob.u0.jump_u)
         @test all(u0old != sjm_prob.prob.u0.jump_u)
         u0old .= sjm_prob.prob.u0.jump_u
@@ -272,7 +273,8 @@ end
 
 # accuracy test based on 
 # https://github.com/SciML/JumpProcesses.jl/issues/320
-# note that testing that precisely is not trivial
+# note that even with the seeded StableRNG this test is not 
+# deterministic for some reason.
 let
     rng = StableRNG(12345)
     b = 2.0
@@ -304,7 +306,7 @@ let
     d_jump = VariableRateJump(d_rate, death!)
 
     ode_prob = ODEProblem(ode_fxn, u0, tspan, p)
-    sjm_prob = JumpProblem(ode_prob, b_jump, d_jump)
+    sjm_prob = JumpProblem(ode_prob, b_jump, d_jump; rng)
     dt = .1
     tsave = range(tspan[1], tspan[2]; step = dt)
     umean = zeros(length(tsave))

--- a/test/variable_rate.jl
+++ b/test/variable_rate.jl
@@ -264,7 +264,7 @@ let
     @test allunique(sjm_prob.prob.u0.jump_u)
     u0old = copy(sjm_prob.prob.u0.jump_u)
     for i in 1:Nsims
-        sol = solve(sjm_prob, Tsit5(); saveat = tspan[2])        
+        sol = solve(sjm_prob, Tsit5(); saveat = tspan[2])
         @test allunique(sjm_prob.prob.u0.jump_u)
         @test all(u0old != sjm_prob.prob.u0.jump_u)
         u0old .= sjm_prob.prob.u0.jump_u
@@ -279,12 +279,12 @@ let
     rng = StableRNG(12345)
     b = 2.0
     d = 1.0
-    n0 = 1 
+    n0 = 1
     tspan = (0.0, 4.0)
     Nsims = 10000
-    n(t) = n0 * exp((b - d)*t)
+    n(t) = n0 * exp((b - d) * t)
     u0 = [n0]
-    p = [b,d]
+    p = [b, d]
 
     function ode_fxn(du, u, p, t)
         du .= 0
@@ -293,7 +293,7 @@ let
 
     b_rate(u, p, t) = (u[1] * p[1])
     function birth!(integrator)
-        integrator.u[1] += 1 
+        integrator.u[1] += 1
         nothing
     end
     b_jump = VariableRateJump(b_rate, birth!)
@@ -307,7 +307,7 @@ let
 
     ode_prob = ODEProblem(ode_fxn, u0, tspan, p)
     sjm_prob = JumpProblem(ode_prob, b_jump, d_jump; rng)
-    dt = .1
+    dt = 0.1
     tsave = range(tspan[1], tspan[2]; step = dt)
     umean = zeros(length(tsave))
     for i in 1:Nsims
@@ -315,5 +315,5 @@ let
         umean .+= Array(sol(tsave; idxs = 1))
     end
     umean ./= Nsims
-    @test all(abs.(umean .- n.(tsave)) .< .05 * n.(tsave))
+    @test all(abs.(umean .- n.(tsave)) .< 0.05 * n.(tsave))
 end


### PR DESCRIPTION
It seems that the code to reset variable rate jump problems was not correctly broadcasting calls to `randexp` resulting in the **same** samples being used for all jumps.

cc: @ChrisRackauckas 

Closes https://github.com/SciML/JumpProcesses.jl/issues/320