### PR TITLE
Update CI to properly use Julia version matrix

### DIFF
--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -31,6 +31,6 @@ jobs:
           - InterfaceII
     uses: "SciML/.github/.github/workflows/tests.yml@v1"
     with:
-      julia-version: '1'
+      julia-version: "${{ matrix.version }}"
       group: ${{ matrix.group }}
     secrets: "inherit"


### PR DESCRIPTION
## Summary
- Fix CI configuration to use `\${{ matrix.version }}` instead of hardcoded '1'
- Enables proper testing on Julia 1, lts, and pre versions as already configured in matrix
- Aligns with SciML ecosystem standards

## Test plan
- [x] Validate YAML syntax
- [ ] Verify CI now runs on all three Julia versions after merge

🤖 Generated with [Claude Code](https://claude.ai/code)