### PR TITLE
Fix autodiff Bool parameter deprecation warnings

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -53,6 +53,7 @@ UnPack = "1.0.2"
 julia = "1.10"
 
 [extras]
+ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"
 FastBroadcast = "7034ab61-46d4-4ed7-9d0f-46aef9175898"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 LinearSolve = "7ed4a6bd-45f5-4d41-b270-4a48e9bafcae"
@@ -65,4 +66,4 @@ StochasticDiffEq = "789caeaf-c7a9-5a7d-9973-96adeb23e2a0"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["LinearAlgebra", "LinearSolve", "OrdinaryDiffEq", "Pkg", "SafeTestsets", "StableRNGs", "Statistics", "StochasticDiffEq", "Test", "FastBroadcast"]
+test = ["ADTypes", "LinearAlgebra", "LinearSolve", "OrdinaryDiffEq", "Pkg", "SafeTestsets", "StableRNGs", "Statistics", "StochasticDiffEq", "Test", "FastBroadcast"]

--- a/test/variable_rate.jl
+++ b/test/variable_rate.jl
@@ -1,6 +1,6 @@
 using DiffEqBase, JumpProcesses, OrdinaryDiffEq, StochasticDiffEq, Test
 using Random, LinearSolve, Statistics
-using StableRNGs
+using StableRNGs, ADTypes
 rng = StableRNG(12345)
 
 a = ExtendedJumpArray(rand(rng, 3), rand(rng, 2))
@@ -33,13 +33,13 @@ prob = ODEProblem(f, [0.2], (0.0, 10.0))
 jump_prob = JumpProblem(prob, jump, jump2; vr_aggregator = VR_FRM(), rng)
 integrator = init(jump_prob, Tsit5())
 sol = solve(jump_prob, Tsit5())
-sol = solve(jump_prob, Rosenbrock23(autodiff = false))
+sol = solve(jump_prob, Rosenbrock23(autodiff = AutoFiniteDiff()))
 sol = solve(jump_prob, Rosenbrock23())
 
 jump_prob_gill = JumpProblem(prob, jump, jump2; vr_aggregator = VR_Direct(), rng)
 integrator = init(jump_prob_gill, Tsit5())
 sol_gill = solve(jump_prob_gill, Tsit5())
-sol_gill = solve(jump_prob, Rosenbrock23(autodiff = false))
+sol_gill = solve(jump_prob, Rosenbrock23(autodiff = AutoFiniteDiff()))
 sol_gill = solve(jump_prob, Rosenbrock23())
 @test maximum([sol.u[i][2] for i in 1:length(sol)]) <= 1e-12
 @test maximum([sol.u[i][3] for i in 1:length(sol)]) <= 1e-12


### PR DESCRIPTION
## Summary
- Replace deprecated `autodiff=false` with proper ADType specifier `autodiff=AutoFiniteDiff()`
- Add ADTypes dependency to test extras and targets

## Problem
CI logs show deprecation warnings from OrdinaryDiffEqCore:
```
Warning: Using a `Bool` for keyword argument `autodiff` is deprecated. Please use an `ADType` specifier.
```

## Solution  
- Changed `Rosenbrock23(autodiff = false)` to `Rosenbrock23(autodiff = AutoFiniteDiff())`
- Added `ADTypes` to Project.toml [extras] and [targets] sections
- Added `using ADTypes` to the test file

## Test plan
- [x] Verify tests still pass with new ADType specifier
- [x] Confirm deprecation warnings are eliminated

🤖 Generated with [Claude Code](https://claude.ai/code)