### PR TITLE
Propagate RNG through VR_FRM callbacks

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "JumpProcesses"
 uuid = "ccbc3e58-028d-4f4c-8cd5-9ae44345cda5"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "9.29.3"
+version = "9.29.4"
 
 [deps]
 ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"

--- a/src/variable_rate.jl
+++ b/src/variable_rate.jl
@@ -230,7 +230,7 @@ end
 function build_variable_callback(cb, idx, jump, jumps...; rng = DEFAULT_RNG)
     idx += 1
     new_cb = wrap_jump_in_callback(idx, jump; rng)
-    build_variable_callback(CallbackSet(cb, new_cb), idx, jumps...; rng = DEFAULT_RNG)
+    build_variable_callback(CallbackSet(cb, new_cb), idx, jumps...; rng)
 end
 
 function build_variable_callback(cb, idx, jump; rng = DEFAULT_RNG)

--- a/test/variable_rate.jl
+++ b/test/variable_rate.jl
@@ -36,6 +36,25 @@ sol = solve(jump_prob, Tsit5())
 sol = solve(jump_prob, Rosenbrock23(autodiff = AutoFiniteDiff()))
 sol = solve(jump_prob, Rosenbrock23())
 
+function vrfrm_trajectory(default_seed)
+    task = @task begin
+        Random.seed!(default_seed)
+        local_rng = StableRNG(12345)
+        ode_prob = ODEProblem((du, u, p, t) -> fill!(du, 0), [0.0], (0.0, 1.0))
+        jump1 = VariableRateJump((u, p, t) -> 1.0,
+            integrator -> (integrator.u[1] += 1))
+        jump2 = VariableRateJump((u, p, t) -> 10.0,
+            integrator -> (integrator.u[1] += 1))
+        jump_prob = JumpProblem(ode_prob, jump1, jump2; vr_aggregator = VR_FRM(),
+            rng = local_rng)
+        solve(jump_prob, Tsit5(); saveat = 0.0:0.05:1.0).u
+    end
+    schedule(task)
+    return fetch(task)
+end
+
+@test vrfrm_trajectory(123) == vrfrm_trajectory(456)
+
 jump_prob_gill = JumpProblem(prob, jump, jump2; vr_aggregator = VR_Direct(), rng)
 integrator = init(jump_prob_gill, Tsit5())
 sol_gill = solve(jump_prob_gill, Tsit5())
@@ -271,8 +290,6 @@ end
 
 # accuracy test based on 
 # https://github.com/SciML/JumpProcesses.jl/issues/320
-# note that even with the seeded StableRNG this test is not 
-# deterministic for some reason.
 function getmean(Nsims, prob, alg, tsave, seed)
     umean = zeros(length(tsave))
     integrator = init(prob, alg; saveat = tsave, seed)


### PR DESCRIPTION
Ignore this PR until it has been reviewed by @ChrisRackauckas.

## What changed and why

Propagate the user-supplied RNG through every recursive `VR_FRM` variable-rate callback instead of reverting callback 2 and later to `DEFAULT_RNG`. Add a public-behavior reproducibility regression and remove the obsolete note that the seeded birth/death test remains nondeterministic.

JumpProcesses is bumped from 9.29.3 to 9.29.4. No public API or dependency changes are included.

## Root cause

The first recursive callback received the `JumpProblem` RNG, but `build_variable_callback` explicitly passed `rng = DEFAULT_RNG` when building the remaining callbacks. Consequently, a supplied `StableRNG` controlled only the first variable-rate jump; task-default RNG state still changed later jump trajectories and made the existing statistical test genuinely nondeterministic.

Pickaxe and parent verification identify the first bad source commit as https://github.com/SciML/JumpProcesses.jl/commit/58e5b6afcaf64a8997385de44a073280fa1a76d1 from https://github.com/SciML/JumpProcesses.jl/pull/477.

## Failing before

The new test constructs the same public `JumpProblem` twice with an identical supplied `StableRNG(12345)`, while varying only the task-default seeds 123 and 456. On unfixed current master, the identical official InterfaceI test reports two different trajectories:

```text
x == y = false
Variable Rate Tests | 75 pass, 1 fail, 76 total
Testing JumpProcesses tests failed
```

This reproduces the mechanism behind the downstream statistical failure exposed here:

https://github.com/SciML/SciMLBase.jl/actions/runs/32365988822/job/96415492959

## Passing after

With the one-line recursive propagation fix, the identical focused test prints:

```text
x == y = true
```

The full owning gates pass on the final version-bumped tree:

```text
GROUP=InterfaceI
Variable Rate Tests | 76/76
All InterfaceI testsets | 861 assertions passed
Testing JumpProcesses tests passed

GROUP=QA
QA | 17/17
Testing JumpProcesses tests passed
```

Runic on both changed Julia files, typos over all three changed files, and `git diff --check` pass.

## Not verified

Julia LTS/prerelease, GPU paths, downstream packages, and the docs build were not run locally. A docs build was not required because this changes no public declaration, signature, docstring, or documentation file.

Related historical accuracy report: https://github.com/SciML/JumpProcesses.jl/issues/320