### PR TITLE
Avoid duplicate callbacks for SDE jump solves

### DIFF
--- a/ext/JumpProcessesOrdinaryDiffEqCoreExt.jl
+++ b/ext/JumpProcessesOrdinaryDiffEqCoreExt.jl
@@ -25,4 +25,12 @@ function SciMLBase.__init(
     _jump_init(_jump_prob, alg; kwargs...)
 end
 
+function SciMLBase.__solve(
+        jump_prob::JumpProcesses.JumpProblem{IIP, P},
+        alg::Union{StochasticDiffEqAlgorithm, StochasticDiffEqRODEAlgorithm};
+        kwargs...
+    ) where {IIP, P <: SciMLBase.AbstractRODEProblem}
+    return JumpProcesses.__jump_solve(jump_prob, alg; kwargs...)
+end
+
 end

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -1,23 +1,18 @@
-function SciMLBase.__solve(jump_prob::JumpProblem{IIP, P},
+function SciMLBase.__solve(
+        jump_prob::JumpProblem{IIP, P},
         alg::SciMLBase.AbstractDEAlgorithm;
-        merge_callbacks = true, kwargs...) where {IIP, P}
-    # Merge jump_prob.kwargs with passed kwargs
-    kwargs = DiffEqBase.merge_problem_kwargs(jump_prob; merge_callbacks, kwargs...)
-
-    integrator = __jump_init(jump_prob, alg; kwargs...)
-    solve!(integrator)
-    integrator.sol
+        merge_callbacks = true, kwargs...
+    ) where {IIP, P}
+    return __jump_solve(jump_prob, alg; merge_callbacks, kwargs...)
 end
 
-function SciMLBase.__solve(jump_prob::JumpProblem{IIP, P},
-        alg::Union{SciMLBase.AbstractRODEAlgorithm, SciMLBase.AbstractSDEAlgorithm};
-        merge_callbacks = true, kwargs...) where {IIP, P}
+function __jump_solve(jump_prob, alg; merge_callbacks = true, kwargs...)
     # Merge jump_prob.kwargs with passed kwargs
     kwargs = DiffEqBase.merge_problem_kwargs(jump_prob; merge_callbacks, kwargs...)
 
     integrator = __jump_init(jump_prob, alg; kwargs...)
     solve!(integrator)
-    integrator.sol
+    return integrator.sol
 end
 
 # if passed a JumpProblem over a DiscreteProblem, and no aggregator is selected use

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -39,6 +39,11 @@ end
         @time @safetestset "Extinction test" begin include("extinction_test.jl") end
     end
     if GROUP == "All" || GROUP == "InterfaceII"
+        @time @safetestset "SDE callback tests" begin
+            run(
+                `$(Base.julia_cmd()) --startup-file=no --project=$(Base.active_project()) $(joinpath(@__DIR__, "sde_callbacks.jl"))`
+            )
+        end
         @time @safetestset "Saveat Regression test" begin include("saveat_regression.jl") end
         @time @safetestset "Save_positions test" begin include("save_positions.jl") end
         @time @safetestset "Ensemble Uniqueness test" begin include("ensemble_uniqueness.jl") end

--- a/test/sde_callbacks.jl
+++ b/test/sde_callbacks.jl
@@ -1,0 +1,27 @@
+using Random: Xoshiro
+using SciMLBase: DiscreteCallback, SDEProblem
+using StochasticDiffEq: SOSRI
+using JumpProcesses
+using Test
+
+@testset "SDE problem callbacks are not duplicated" begin
+    f!(du, u, p, t) = (du[1] = 0.0)
+    g!(du, u, p, t) = (du[1] = 0.0)
+    callback_count = Ref(0)
+    condition(u, t, integrator) = t == 0.5
+    function affect!(integrator)
+        callback_count[] += 1
+        integrator.u[1] += 10.0
+    end
+    callback = DiscreteCallback(condition, affect!)
+    problem = SDEProblem(f!, g!, [0.0], (0.0, 1.0))
+    jump = ConstantRateJump((u, p, t) -> 0.0, integrator -> nothing)
+    jump_problem = JumpProblem(
+        problem, Direct(), jump; callback, rng = Xoshiro(12345), tstops = [0.5]
+    )
+
+    solution = solve(jump_problem, SOSRI())
+
+    @test callback_count[] == 1
+    @test solution.u[end][1] == 10.0
+end


### PR DESCRIPTION
This PR should be ignored until reviewed by @ChrisRackauckas.

## What changed

JumpProcesses 9.30.1 added an SDE-specialized `SciMLBase.__solve` with the same effective signature as StochasticDiffEqCore's method. Which method survived depended on package/precompile load order. When StochasticDiffEqCore's method was active, it merged a `JumpProblem`'s callbacks and then delegated to JumpProcesses' specialized initialization, which merged them again; a discrete callback consequently fired twice.

This factors the existing one-merge solve path into a local helper and adds an extension method constrained by both the SDE algorithm and the wrapped RODE/SDE problem. That method is strictly more specific than StochasticDiffEqCore's method and owns the one-merge path regardless of load order.

The behavior first appeared in https://github.com/SciML/JumpProcesses.jl/commit/111b04e62a4391efa6e4d393cde7c6ea33c5be89 and caused ModelingToolkit downstream jump-event assertions on https://github.com/SciML/BoundaryValueDiffEq.jl/pull/613 to observe approximately 200/400 instead of 100/200.

## Failing before

On clean JumpProcesses v9.30.1, with `StochasticDiffEq` loaded before `JumpProcesses`:

```
callback_count[] == 1
Evaluated: 2 == 1
solution.u[end][1] == 10.0
Evaluated: 20.0 == 10.0
SDE problem callbacks are not duplicated | 0 passed, 2 failed
```

## Passing after

The same regression test after this patch:

```
SDE problem callbacks are not duplicated | 2 pass | 2 total | 11.2s
```

The exact downstream ModelingToolkit reproducer after developing this checkout:

```
sol(1.001) - sol(0.999) = 100.00084345159574
sol(3.001) - sol(2.999) = 200.00097745054813
```

Before the patch, the same values were approximately `200.001` and `400.001`.

## Verification

- `GROUP=InterfaceII julia +1.11 --project=. -e 'using Pkg; Pkg.test()'`
  - `Testing JumpProcesses tests passed`
  - 571.7 seconds; all InterfaceII testsets passed.
- Targeted new regression: 2/2 passed.
- Targeted ModelingToolkit jumpsystem assertions: expected 100/200 behavior restored.
- Runic check passed on all added/changed ranges and the new test.
- `typos` passed on all changed files.
- `git diff --check` passed.

`GROUP=QA` is red on both this branch and clean v9.30.1 with the identical pre-existing ExplicitImports error: qualified `Base.Iterators.map` and `Base.Iterators.filter` are not public. Result in both cases: 19 passed, 1 errored. This PR intentionally does not mix that unrelated mechanical fix.

No documentation build was run because this changes no public API or documentation. GPU paths were not tested.

🤖 Generated with Codex CLI 0.150.1 (model: unknown; session: local session ID 01a0441e-3d2f-7170-ab6e-58ef72975a9f)
