### PR TITLE
Ignore ForwardDiff.Dual in ExplicitImports QA

### DIFF
--- a/test/qa.jl
+++ b/test/qa.jl
@@ -39,6 +39,10 @@ run_qa(
                 :updated_u0_p,
                 # DiffEqBase non-public
                 :Stats,
+                # ForwardDiff: Dual is the AD number type used in
+                # ext/JumpProcessesForwardDiffExt.jl. It is exported but not
+                # declared `public` in ForwardDiff's released API.
+                :Dual,
                 # LinearAlgebra non-public
                 :AbstractQ, :AdjointQ, :QRPackedQ,
                 # FunctionWrappers non-public


### PR DESCRIPTION
> Ignore this PR until it has been reviewed by @ChrisRackauckas.

## Summary

Master QA (`all_qualified_accesses_are_public`) fails because `JumpProcessesForwardDiffExt` dispatches on `ForwardDiff.Dual`, which is exported but not declared `public` in ForwardDiff's released API. Dual is the AD number type; there is no public replacement. Add it to the existing ExplicitImports ignore-list (same pattern as SciMLBase / DiffEqBase / LinearAlgebra internals already listed).

Own tests were already green. This is the QA job only. The docs `gh-pages` push failure is unchanged.

## Verification

Fail-before (`GROUP=QA julia +1.12 --project -e 'using Pkg; Pkg.test()'`):

```
all_qualified_accesses_are_public: Error During Test
NonPublicQualifiedAccessException
- Dual is not public in ForwardDiff but it was imported from ForwardDiff at
  ext/JumpProcessesForwardDiffExt.jl:8:44
QA Tests | 19 pass, 1 error
```

Pass-after (same command):

```
QA Tests | 20 pass, 0 error
Testing JumpProcesses tests passed
```

## What was not verified

- InterfaceI / InterfaceII / GPU groups
- Documentation deploy (pre-existing gh-pages push failure)

🤖 Generated with Grok Build TUI 1.0.13 (model: grok-4.6)

Session: local `01a05208-1801-7323-a40d-daf68951e609` (transcript `/home/crackauc/.grok/sessions/%2Fhome%2Fcrackauc%2Fsandbox%2Ftmp_20260830_093701_61089/01a05208-1801-7323-a40d-daf68951e609`).