### PR TITLE
Add a GPU kernel for SimpleExplicitTauLeaping

### DIFF
--- a/ext/JumpProcessesKernelAbstractionsExt.jl
+++ b/ext/JumpProcessesKernelAbstractionsExt.jl
@@ -6,6 +6,7 @@ using StaticArrays
 using PoissonRandom, Random
 
 include("ssa_stepper.jl")
+include("explicit_tau_leaping.jl")
 
 function SciMLBase.__solve(ensembleprob::SciMLBase.AbstractEnsembleProblem,
         alg::SimpleTauLeaping,

--- a/ext/explicit_tau_leaping.jl
+++ b/ext/explicit_tau_leaping.jl
@@ -11,6 +11,8 @@ host, so the device only evaluates the closed form.
 """
 @inline function gpu_compute_gi(u, max_hor, max_stoich, i, ::Type{RT}) where {RT}
     onert = one(RT)
+    two = 2 * onert
+    three = 3 * onert
 
     @inbounds begin
         hor = max_hor[i]
@@ -18,25 +20,27 @@ host, so the device only evaluates the closed form.
         x = RT(u[i])
     end
 
-    if hor <= 1                     # species i is not a reactant, or first order
-        return onert
-    elseif hor == 2
-        stoich == 1 && return 2 * onert
-        # 2S_i -> products; fall back to 2 when x_i <= 1
-        return x > onert ? 2 * onert + onert / (x - onert) : 2 * onert
-    elseif hor == 3
-        stoich == 1 && return 3 * onert
-        if stoich == 2
-            # 2S_i + S_k -> products; fall back to 3 when x_i <= 1
-            return x > onert ?
-                   (3 * onert / 2) * (2 * onert + onert / (x - onert)) : 3 * onert
-        end
-        # 3S_i -> products; fall back to 3 when x_i <= 2
-        return x > 2 * onert ?
-               3 * onert + onert / (x - onert) + 2 * onert / (x - 2 * onert) : 3 * onert
-    end
+    # Written with `ifelse` rather than branches so that threads of a warp that
+    # land on different reaction orders do not diverge. Both arms are therefore
+    # always evaluated: when x_i is too small the reciprocals below divide by
+    # zero or go negative, but IEEE division yields +/-Inf rather than trapping,
+    # and those values are exactly the ones the selects discard.
+    inv_xm1 = onert / (x - onert)     # 1 / (x_i - 1)
+    inv_xm2 = two / (x - two)         # 2 / (x_i - 2)
 
-    return onert
+    # 2S_i -> products; fall back to 2 when x_i <= 1
+    g2_s2 = ifelse(x > onert, two + inv_xm1, two)
+    # 2S_i + S_k -> products is exactly 3/2 of the order 2 form, including its
+    # fallback, so it reuses it rather than recomputing the reciprocal
+    g3_s2 = (three / two) * g2_s2
+    # 3S_i -> products; fall back to 3 when x_i <= 2
+    g3_s3 = ifelse(x > two, three + inv_xm1 + inv_xm2, three)
+
+    g_hor2 = ifelse(stoich == 1, two, g2_s2)
+    g_hor3 = ifelse(stoich == 1, three, ifelse(stoich == 2, g3_s2, g3_s3))
+
+    # hor 0 and 1, and anything unsupported, take the default of 1
+    return ifelse(hor == 2, g_hor2, ifelse(hor == 3, g_hor3, onert))
 end
 
 """
@@ -85,8 +89,11 @@ entries the host walks past are zero.
         bound = max(epsilon * RT(u[i]) / gi, one(RT))   # max(epsilon x_i / g_i, 1)
         m = abs(mu[i])
         s = sigma2[i]
-        mu_term = m > zero(RT) ? bound / m : typemax(RT)              # eq. (8), first term
-        sigma_term = s > zero(RT) ? bound * bound / s : typemax(RT)   # eq. (8), second term
+        zed = zero(RT)
+        # branch-free for the same reason as above; a zero denominator gives Inf,
+        # which the select discards in favour of typemax
+        mu_term = ifelse(m > zed, bound / m, typemax(RT))              # eq. (8), first term
+        sigma_term = ifelse(s > zed, bound * bound / s, typemax(RT))   # eq. (8), second term
         tau = min(tau, mu_term, sigma_term)
     end
 

--- a/ext/explicit_tau_leaping.jl
+++ b/ext/explicit_tau_leaping.jl
@@ -1,0 +1,321 @@
+"""
+    gpu_compute_gi(u, max_hor, max_stoich, i, ::Type{RT})
+
+Bound on the relative change of the propensities in species `i`, `g_i`, as in
+Cao et al. (2006), Section IV, equation (27).
+
+Mirrors `JumpProcesses.compute_gi`. `max_hor[i]` is the highest order of any
+reaction that consumes species `i`, and `max_stoich[i]` is the largest
+stoichiometry it appears with in such a reaction; both are precomputed on the
+host, so the device only evaluates the closed form.
+"""
+@inline function gpu_compute_gi(u, max_hor, max_stoich, i, ::Type{RT}) where {RT}
+    onert = one(RT)
+
+    @inbounds begin
+        hor = max_hor[i]
+        stoich = max_stoich[i]
+        x = RT(u[i])
+    end
+
+    if hor <= 1                     # species i is not a reactant, or first order
+        return onert
+    elseif hor == 2
+        stoich == 1 && return 2 * onert
+        # 2S_i -> products; fall back to 2 when x_i <= 1
+        return x > onert ? 2 * onert + onert / (x - onert) : 2 * onert
+    elseif hor == 3
+        stoich == 1 && return 3 * onert
+        if stoich == 2
+            # 2S_i + S_k -> products; fall back to 3 when x_i <= 1
+            return x > onert ?
+                   (3 * onert / 2) * (2 * onert + onert / (x - onert)) : 3 * onert
+        end
+        # 3S_i -> products; fall back to 3 when x_i <= 2
+        return x > 2 * onert ?
+               3 * onert + onert / (x - onert) + 2 * onert / (x - 2 * onert) : 3 * onert
+    end
+
+    return onert
+end
+
+"""
+    gpu_compute_tau(u, maj, max_hor, max_stoich, epsilon, dtmin, ::Type{RT})
+
+Select the leap size at state `u`, following equation (20) of Cao et al. (2006),
+and report whether any reaction can still fire.
+
+Mirrors `JumpProcesses.compute_tau`, with one difference in how the moments are
+accumulated. The host version sums `mu_i = sum_j nu_ij a_j` and
+`sigma_i^2 = sum_j nu_ij^2 a_j` over the dense stoichiometry matrix. Here each
+propensity is evaluated once and scattered into per-species accumulators through
+the net stoichiometry, which visits only the nonzeros and so needs neither the
+dense matrix nor a propensity cache in global memory. The two agree because the
+entries the host walks past are zero.
+"""
+@inline function gpu_compute_tau(u, maj, max_hor, max_stoich, epsilon, dtmin,
+        ::Type{RT}) where {RT}
+    numjumps = gpu_num_jumps(maj)
+    nspec = length(u)
+
+    mu = zero(MVector{nspec, RT})
+    sigma2 = zero(MVector{nspec, RT})
+    can_react = false
+
+    @inbounds for j in 1:numjumps
+        a = gpu_evalrxrate(u, j, maj, RT)
+        a > zero(RT) && (can_react = true)
+
+        lo = maj.ns_offsets[j]
+        hi = maj.ns_offsets[j + 1] - one(eltype(maj.ns_offsets))
+        for k in lo:hi
+            spec = maj.ns_species[k]
+            v = RT(maj.ns_coeffs[k])
+            mu[spec] += v * a
+            sigma2[spec] += v * v * a
+        end
+    end
+
+    # No reaction can fire, so there is no leap to size.
+    can_react || return dtmin, false
+
+    tau = typemax(RT)
+    @inbounds for i in 1:nspec
+        gi = gpu_compute_gi(u, max_hor, max_stoich, i, RT)
+        bound = max(epsilon * RT(u[i]) / gi, one(RT))   # max(epsilon x_i / g_i, 1)
+        m = abs(mu[i])
+        s = sigma2[i]
+        mu_term = m > zero(RT) ? bound / m : typemax(RT)              # eq. (8), first term
+        sigma_term = s > zero(RT) ? bound * bound / s : typemax(RT)   # eq. (8), second term
+        tau = min(tau, mu_term, sigma_term)
+    end
+
+    return max(tau, dtmin), true
+end
+
+"""
+    explicit_tau_leaping_kernel!(us, u0, maj, max_hor, max_stoich, saveat, t0, tend,
+                                 epsilon, dtmin)
+
+Advance one explicit tau-leaping trajectory per thread, writing the state
+sampled on the `saveat` grid into `us[trajectory, species, save_idx]`.
+
+The leap size is chosen per trajectory and per step, so trajectories fall out of
+step with one another; the grid is what gives them a common, fixed-size output.
+`tau` is shortened to land exactly on the next grid point when a step would
+overshoot it, which is what the host solver does too, so a saved value is always
+a state the trajectory actually occupied rather than an interpolation.
+
+The state lives in registers as an `SVector` and the propensities are evaluated
+twice per step, once to size the leap and once to draw the counts, so the kernel
+needs no per-thread scratch in global memory.
+"""
+@kernel function explicit_tau_leaping_kernel!(us, u0, maj, @Const(max_hor),
+        @Const(max_stoich), @Const(saveat), t0, tend, epsilon, dtmin)
+    i = @index(Global, Linear)
+
+    @inbounds begin
+        RT = eltype(saveat)
+        numjumps = gpu_num_jumps(maj)
+        nsave = length(saveat)
+        rng = PoissonRandom.PassthroughRNG()
+
+        u = u0
+        t = RT(t0)
+
+        # Grid points at or before the initial time hold the initial condition.
+        sidx = 1
+        while sidx <= nsave && saveat[sidx] <= t
+            store_state!(us, u, sidx, i)
+            sidx += 1
+        end
+
+        # Upper bound on the next leap, carried across iterations so that a
+        # rejected leap actually retries with a smaller one. Recomputing tau from
+        # scratch would otherwise reproduce the rejected size.
+        tau_cap = typemax(RT)
+
+        while sidx <= nsave
+            tau, can_react = gpu_compute_tau(
+                u, maj, max_hor, max_stoich, epsilon, dtmin, RT)
+
+            # Nothing can fire again, so the path is constant on the rest of the grid.
+            if !can_react
+                while sidx <= nsave
+                    store_state!(us, u, sidx, i)
+                    sidx += 1
+                end
+                break
+            end
+
+            tau = min(tau, tau_cap, tend - t)
+            # Shorten the leap so it lands on the next grid point rather than past it.
+            if saveat[sidx] - t < tau
+                tau = saveat[sidx] - t
+            end
+
+            # Poisson counts come from the backend's device RNG, the same
+            # generator the SimpleTauLeaping kernel draws from.
+            u_new = u
+            for j in 1:numjumps
+                lambda = gpu_evalrxrate(u, j, maj, RT) * tau
+                lambda <= zero(RT) && continue
+                count = pois_rand(rng, lambda)
+                count == 0 && continue
+
+                lo = maj.ns_offsets[j]
+                hi = maj.ns_offsets[j + 1] - one(eltype(maj.ns_offsets))
+                for k in lo:hi
+                    spec = maj.ns_species[k]
+                    u_new = setindex(u_new, u_new[spec] + maj.ns_coeffs[k] * count, spec)
+                end
+            end
+
+            negative = false
+            for k in eachindex(u_new)
+                u_new[k] < zero(eltype(u_new)) && (negative = true)
+            end
+            if negative
+                # Halve tau to avoid negative populations, as per Cao et al. (2006), Section 3.3
+                tau <= dtmin && break
+                tau_cap = tau / 2
+                continue
+            end
+
+            t += tau
+            u = u_new
+
+            if t >= saveat[sidx]
+                store_state!(us, u, sidx, i)
+                sidx += 1
+            end
+            tau_cap = typemax(RT)   # release the bound after a good leap
+        end
+    end
+end
+
+"""
+    __solve(ensembleprob, ::SimpleExplicitTauLeaping, ::EnsembleGPUKernel;
+            trajectories, saveat, ...)
+
+Solve an ensemble of mass action `JumpProblem`s with one explicit tau-leaping
+trajectory per GPU thread.
+
+`saveat` is required. The leap size adapts to the state, so the number of steps a
+trajectory takes is not known in advance and the solution is sampled onto a fixed
+time grid instead. Each returned solution therefore contains exactly the grid
+points, as if the problem had been built with `save_positions = (false, false)`.
+
+Randomness comes from the backend's own device RNG rather than the `rng` stored
+in the `JumpProblem`. `seed` is applied to the ambient generator, so it makes a
+run reproducible on backends that draw from it, such as `CPU()`; seeding a GPU
+backend is done through that backend's own `seed!`.
+
+The reaction data is uploaded to the device once and shared by every thread, so
+all trajectories solve the same problem and a `prob_func` is not supported.
+"""
+function SciMLBase.__solve(ensembleprob::SciMLBase.AbstractEnsembleProblem,
+        alg::SimpleExplicitTauLeaping,
+        ensemblealg::EnsembleGPUKernel;
+        trajectories,
+        seed = nothing,
+        dtmin = nothing,
+        saveat = nothing,
+        save_start = true,
+        save_end = true,
+        callback = nothing,
+        kwargs...)
+    if trajectories == 1
+        return SciMLBase.__solve(ensembleprob, alg, EnsembleSerial(); trajectories = 1,
+            seed, dtmin, saveat, save_start, save_end, callback, kwargs...)
+    end
+
+    callback === nothing ||
+        error("EnsembleGPUKernel with SimpleExplicitTauLeaping does not support callbacks, \
+               since they would have to run inside the GPU kernel.")
+
+    seed !== nothing && Random.seed!(seed)
+
+    ensemblealg.backend === nothing ? backend = CPU() : backend = ensemblealg.backend
+
+    jump_prob = ensembleprob.prob
+    jump_prob isa JumpProblem ||
+        error("EnsembleGPUKernel with SimpleExplicitTauLeaping requires a JumpProblem, got $(typeof(jump_prob)).")
+
+    validate_gpu_massaction_inputs(jump_prob) ||
+        error("EnsembleGPUKernel with SimpleExplicitTauLeaping only supports JumpProblems \
+               built from a DiscreteProblem whose jumps are all MassActionJumps, with no \
+               user callbacks. RegularJumps are not supported here because their rate and \
+               `c` are arbitrary Julia functions that cannot be evaluated inside a GPU \
+               kernel; rewrite them as MassActionJumps to use this solver.")
+
+    # The leap size adapts to the state, so there is no trajectory length to
+    # allocate up front. Sampling on a time grid gives every trajectory the same,
+    # exactly known output size.
+    saveat === nothing &&
+        error("EnsembleGPUKernel with SimpleExplicitTauLeaping requires `saveat`, since \
+               the leap size adapts to the state and the number of steps a trajectory \
+               takes is not known ahead of time. Pass a step (`saveat = 1.0`) or an \
+               explicit collection of times.")
+
+    ensembleprob.prob_func === SciMLBase.DEFAULT_PROB_FUNC ||
+        error("EnsembleGPUKernel with SimpleExplicitTauLeaping does not support a \
+               `prob_func`; the reaction data is uploaded to the device once and shared \
+               by every trajectory. Ensembles of differing problems have to be solved \
+               with a CPU ensemble algorithm such as EnsembleThreads.")
+
+    prob = jump_prob.prob
+    maj = jump_prob.massaction_jump
+
+    TT = float(eltype(prob.tspan))
+    t0, tend = TT(prob.tspan[1]), TT(prob.tspan[2])
+    dtmin === nothing && (dtmin = 1.0e-10 * one(TT))
+
+    save_times = gpu_save_times(saveat, (t0, tend), save_start, save_end)
+    nsave = length(save_times)
+
+    state_dim = length(prob.u0)
+    ET = eltype(prob.u0)
+    state_dim > 0 || error("The state must have at least one species.")
+
+    # Every trajectory starts from the same state, so it is passed by value and
+    # lives in registers rather than being uploaded once per thread.
+    u0 = SVector{state_dim, ET}(prob.u0)
+    saveat_gpu = adapt(backend, save_times)
+    maj_gpu = GPUMassActionJump(maj, backend, TT)
+
+    # g_i depends only on the reactant stoichiometry, so the per-species highest
+    # order and largest stoichiometry are precomputed once on the host.
+    reactant_stoch = maj.reactant_stoch
+    numjumps = JumpProcesses.get_num_majumps(maj)
+    hor = JumpProcesses.compute_hor(reactant_stoch, numjumps)
+    max_hor, max_stoich = JumpProcesses.precompute_reaction_conditions(
+        reactant_stoch, hor, state_dim, numjumps)
+    max_hor_gpu = adapt(backend, convert(Vector{Int32}, max_hor))
+    max_stoich_gpu = adapt(backend, convert(Vector{Int32}, max_stoich))
+
+    us = allocate(backend, ET, (trajectories, state_dim, nsave))
+
+    kernel = explicit_tau_leaping_kernel!(backend)
+    kernel(us, u0, maj_gpu, max_hor_gpu, max_stoich_gpu, saveat_gpu, t0, tend,
+        TT(alg.epsilon), TT(dtmin); ndrange = trajectories)
+    KernelAbstractions.synchronize(backend)
+
+    _us = Array(us)
+
+    time = @elapsed sol = [begin
+                               @views ensembleprob.output_func(
+                                   SciMLBase.build_solution(prob,
+                                       alg,
+                                       save_times,
+                                       [_us[i, :, j] for j in 1:nsave],
+                                       k = nothing,
+                                       stats = nothing,
+                                       calculate_error = false,
+                                       retcode = ReturnCode.Success),
+                                   i)[1]
+                           end
+                           for i in 1:trajectories]
+
+    return SciMLBase.EnsembleSolution(sol, time, true)
+end

--- a/ext/ssa_stepper.jl
+++ b/ext/ssa_stepper.jl
@@ -210,13 +210,13 @@ models the extra arithmetic is cheaper than the memory traffic it replaces.
 end
 
 """
-    validate_gpu_ssa_inputs(jump_prob)
+    validate_gpu_massaction_inputs(jump_prob)
 
 The GPU kernel can only run problems whose jumps are all `MassActionJump`s over
 a `DiscreteProblem`, with no user callbacks. The single discrete callback that
 is always present is the jump aggregator itself.
 """
-function validate_gpu_ssa_inputs(jump_prob::JumpProblem)
+function validate_gpu_massaction_inputs(jump_prob::JumpProblem)
     jump_prob.prob isa DiscreteProblem &&
         JumpProcesses.get_num_majumps(jump_prob.massaction_jump) > 0 &&
         isempty(jump_prob.constant_jumps) &&
@@ -228,7 +228,7 @@ end
 
 # Build the vector of times the kernel samples at. Every trajectory shares this
 # grid, so it doubles as the `t` vector of each returned solution.
-function ssa_save_times(saveat, tspan::Tuple{TT, TT}, save_start,
+function gpu_save_times(saveat, tspan::Tuple{TT, TT}, save_start,
         save_end) where {TT <: AbstractFloat}
     t0, tend = tspan
 
@@ -298,7 +298,7 @@ function SciMLBase.__solve(ensembleprob::SciMLBase.AbstractEnsembleProblem,
     jump_prob isa JumpProblem ||
         error("EnsembleGPUKernel with SSAStepper requires a JumpProblem, got $(typeof(jump_prob)).")
 
-    validate_gpu_ssa_inputs(jump_prob) ||
+    validate_gpu_massaction_inputs(jump_prob) ||
         error("EnsembleGPUKernel with SSAStepper only supports JumpProblems built from a \
                DiscreteProblem whose jumps are all MassActionJumps, with no user \
                callbacks. ConstantRateJumps and VariableRateJumps are not supported \
@@ -321,7 +321,7 @@ function SciMLBase.__solve(ensembleprob::SciMLBase.AbstractEnsembleProblem,
     TT = float(eltype(prob.tspan))
     t0, tend = TT(prob.tspan[1]), TT(prob.tspan[2])
 
-    save_times = ssa_save_times(saveat, (t0, tend), save_start, save_end)
+    save_times = gpu_save_times(saveat, (t0, tend), save_start, save_end)
     nsave = length(save_times)
 
     # Every thread reads one shared copy of the stoichiometry, rate constants and

--- a/src/simple_regular_solve.jl
+++ b/src/simple_regular_solve.jl
@@ -382,7 +382,9 @@ end
 # HOR is the sum of stoichiometric coefficients of reactants in reaction j.
 # Extract the element type from reactant_stoch to avoid hardcoding type assumptions.
 function compute_hor(reactant_stoch, numjumps)
-    stoch_type = eltype(first(first(reactant_stoch)))
+    # Taken from the type rather than from an element: a zero order reaction has an
+    # empty reactant stoichiometry, and `first` of that throws.
+    stoch_type = eltype(eltype(eltype(reactant_stoch)))
     hor = zeros(stoch_type, numjumps)
     for j in 1:numjumps
         order = sum(

--- a/test/explicit_tau_kernel_tests.jl
+++ b/test/explicit_tau_kernel_tests.jl
@@ -1,0 +1,163 @@
+using JumpProcesses
+using Test, Statistics
+using KernelAbstractions, Adapt
+
+# Body of the SimpleExplicitTauLeaping kernel tests, run against both a GPU
+# backend and the KernelAbstractions CPU backend so the same behaviour is covered
+# without a GPU.
+#
+# The reference is the serial SimpleExplicitTauLeaping, not the exact SSA: tau
+# leaping carries a discretization bias that grows with `epsilon`, and the kernel
+# is expected to reproduce the host solver including that bias. One test below
+# pins the bias down by checking it shrinks as `epsilon` shrinks.
+function run_explicit_tau_kernel_tests(backend, nsims)
+    leaping_prob(rates, rs, ns, u0, tspan) = JumpProblem(DiscreteProblem(u0, tspan),
+        PureLeaping(), MassActionJump(rates, rs, ns))
+
+    kernel_solve(jp, nsims; kwargs...) = solve(EnsembleProblem(jp),
+        SimpleExplicitTauLeaping(), EnsembleGPUKernel(backend);
+        trajectories = nsims, kwargs...)
+    serial_solve(jp, nsims; kwargs...) = solve(EnsembleProblem(jp),
+        SimpleExplicitTauLeaping(), EnsembleSerial(); trajectories = nsims, kwargs...)
+
+    # Compare the mean of every species at every saved time.
+    function compare_means(jp, nsims, nspec; rtol = 0.05, atol = 0.5, kwargs...)
+        sk = kernel_solve(jp, nsims; kwargs...)
+        ss = serial_solve(jp, nsims; kwargs...)
+        @test sk.u[1].t == ss.u[1].t
+        for k in eachindex(sk.u[1].t), s in 1:nspec
+            mk = mean(sk.u[i].u[k][s] for i in 1:nsims)
+            ms = mean(ss.u[i].u[k][s] for i in 1:nsims)
+            @test isapprox(mk, ms; rtol, atol)
+        end
+        return sk
+    end
+
+    # Linear death X -> 0.
+    let
+        jp = leaping_prob([0.5], [[1 => 1]], [[1 => -1]], [1000.0], (0.0, 4.0))
+        sol = compare_means(jp, nsims, 1; saveat = 1.0)
+        @test sol.u[1].t == [0.0, 1.0, 2.0, 3.0, 4.0]
+        @test sol.u[1].u[1] == [1000.0]
+        # the population can only fall
+        @test all(issorted(reverse([sol.u[i].u[k][1] for k in 1:5])) for i in 1:100)
+    end
+
+    # Zero order 0 -> A, i.e. an empty reactant stoichiometry, so max_hor is 0
+    # for the product species and g_i takes its default value.
+    let
+        jp = leaping_prob([5.0], [Pair{Int, Int}[]], [[1 => 1]], [0.0], (0.0, 4.0))
+        sol = compare_means(jp, nsims, 1; saveat = 2.0)
+        # A(t) is Poisson with mean 5t here, and the leap is exact for a constant rate
+        for (k, t) in enumerate(sol.u[1].t)
+            @test isapprox(mean(sol.u[i].u[k][1] for i in 1:nsims), 5.0 * t,
+                rtol = 0.05, atol = 1.0e-8)
+        end
+    end
+
+    # SIR.
+    let
+        jp = leaping_prob([0.1 / 1000, 0.01], [[1 => 1, 2 => 1], [2 => 1]],
+            [[1 => -1, 2 => 1], [2 => -1, 3 => 1]], [999.0, 10.0, 0.0], (0.0, 250.0))
+        compare_means(jp, nsims, 3; saveat = 50.0)
+    end
+
+    # Second order 2A -> B. Exercises the falling factorial in the propensity and
+    # the g_i branch for max_hor 2 with max_stoich 2.
+    let
+        jp = leaping_prob([0.01], [[1 => 2]], [[1 => -2, 2 => 1]], [1000.0, 0.0],
+            (0.0, 5.0))
+        sol = compare_means(jp, nsims, 2; saveat = 1.0)
+        # A is consumed two at a time, so its parity is conserved along a path
+        @test all(all(iseven, (Int(sol.u[i].u[k][1]) for k in 1:6)) for i in 1:100)
+    end
+
+    # Third order 3A -> B, for the deeper g_i branch (max_hor 3, max_stoich 3).
+    let
+        jp = leaping_prob([1.0e-6], [[1 => 3]], [[1 => -3, 2 => 1]], [1000.0, 0.0],
+            (0.0, 5.0))
+        compare_means(jp, nsims, 2; saveat = 2.5)
+    end
+
+    # Reversible binding A + B <-> C, a multi species model with conservation laws.
+    let
+        jp = leaping_prob([0.001, 0.5], [[1 => 1, 2 => 1], [3 => 1]],
+            [[1 => -1, 2 => -1, 3 => 1], [1 => 1, 2 => 1, 3 => -1]],
+            [1000.0, 800.0, 0.0], (0.0, 10.0))
+        sol = compare_means(jp, nsims, 3; saveat = 5.0)
+        # A + C and B + C are conserved by both reactions
+        @test all(sol.u[i].u[k][1] + sol.u[i].u[k][3] == 1000.0 for i in 1:100, k in 1:3)
+        @test all(sol.u[i].u[k][2] + sol.u[i].u[k][3] == 800.0 for i in 1:100, k in 1:3)
+    end
+
+    # Extinction. Once every molecule is gone no reaction can fire, and the path
+    # has to stay constant for the rest of the grid.
+    let
+        jp = leaping_prob([2.0], [[1 => 1]], [[1 => -1]], [3.0], (0.0, 20.0))
+        sol = kernel_solve(jp, 1000; saveat = 5.0)
+        @test all(sol.u[i].u[end][1] == 0.0 for i in 1:1000)
+        @test all(issorted(reverse([sol.u[i].u[k][1] for k in eachindex(sol.u[i].t)]))
+        for i in 1:1000)
+    end
+
+    # The leap size has to respond to epsilon: a tighter tolerance must move the
+    # mean towards the exact SSA result.
+    let
+        c, x0, tend = 0.5, 1000.0, 4.0
+        jp = leaping_prob([c], [[1 => 1]], [[1 => -1]], [x0], (0.0, tend))
+        exact = x0 * exp(-c * tend)
+        errs = map((0.05, 0.01, 0.002)) do epsilon
+            sol = solve(EnsembleProblem(jp), SimpleExplicitTauLeaping(; epsilon),
+                EnsembleGPUKernel(backend); trajectories = nsims, saveat = tend)
+            abs(mean(sol.u[i].u[end][1] for i in 1:nsims) - exact)
+        end
+        @test errs[1] > errs[2] > errs[3]
+        @test errs[3] < 0.02 * exact
+    end
+
+    # saveat handling and the save_start / save_end flags.
+    let
+        jp = leaping_prob([0.5], [[1 => 1]], [[1 => -1]], [500.0], (0.0, 3.0))
+
+        sol = kernel_solve(jp, 10; saveat = 1.0)
+        @test sol.u[1].t == [0.0, 1.0, 2.0, 3.0]
+        @test sol.u[1].u[1] == [500.0]
+
+        sol = kernel_solve(jp, 10; saveat = [0.5, 1.5, 2.5])
+        @test sol.u[1].t == [0.0, 0.5, 1.5, 2.5, 3.0]
+
+        sol = kernel_solve(jp, 10; saveat = [0.5, 1.5], save_start = false,
+            save_end = false)
+        @test sol.u[1].t == [0.5, 1.5]
+    end
+
+    # Unsupported inputs must be rejected rather than silently producing wrong results.
+    let
+        # a RegularJump cannot be evaluated on the device
+        rj = RegularJump((out, u, p, t) -> (out[1] = 0.5u[1]),
+            (du, u, p, t, counts, mark) -> (du[1] = -counts[1]), 1)
+        rj_prob = JumpProblem(DiscreteProblem([50.0], (0.0, 3.0)), PureLeaping(), rj)
+        @test_throws ErrorException solve(EnsembleProblem(rj_prob),
+            SimpleExplicitTauLeaping(), EnsembleGPUKernel(backend);
+            trajectories = 10, saveat = 1.0)
+
+        maj_prob = leaping_prob([0.5], [[1 => 1]], [[1 => -1]], [50.0], (0.0, 3.0))
+
+        # saveat is mandatory: the leap size adapts, so the step count is unknown
+        @test_throws ErrorException solve(EnsembleProblem(maj_prob),
+            SimpleExplicitTauLeaping(), EnsembleGPUKernel(backend); trajectories = 10)
+
+        @test_throws ErrorException solve(EnsembleProblem(maj_prob),
+            SimpleExplicitTauLeaping(), EnsembleGPUKernel(backend); trajectories = 10,
+            saveat = 1.0,
+            callback = DiscreteCallback((u, t, integrator) -> false,
+                integrator -> nothing))
+
+        # the reaction data is shared by all threads, so trajectories cannot differ
+        varying = EnsembleProblem(maj_prob; prob_func = (prob, ctx) -> prob)
+        @test_throws ErrorException solve(varying, SimpleExplicitTauLeaping(),
+            EnsembleGPUKernel(backend); trajectories = 5, saveat = 1.0)
+    end
+
+    return nothing
+end

--- a/test/gpu/explicit_tau.jl
+++ b/test/gpu/explicit_tau.jl
@@ -1,0 +1,4 @@
+using CUDA
+include(joinpath(@__DIR__, "..", "explicit_tau_kernel_tests.jl"))
+
+run_explicit_tau_kernel_tests(CUDABackend(), 100_000)

--- a/test/kernelabstractions_explicit_tau.jl
+++ b/test/kernelabstractions_explicit_tau.jl
@@ -1,0 +1,6 @@
+include(joinpath(@__DIR__, "explicit_tau_kernel_tests.jl"))
+
+# The same kernel, run through KernelAbstractions' CPU backend so it is covered
+# by the ordinary test suite as well as by the GPU run. Fewer trajectories here
+# since the CPU backend runs them without a GPU's parallelism.
+run_explicit_tau_kernel_tests(CPU(), 20_000)

--- a/test/regular_jumps.jl
+++ b/test/regular_jumps.jl
@@ -256,6 +256,29 @@ end
     end
 end
 
+@testset "Zero order reactions in tau-leaping" begin
+    # A zero order reaction has an empty reactant stoichiometry. `compute_hor`
+    # used to take the element type from the first entry of the first reaction,
+    # which threw a BoundsError for such a model.
+    maj = MassActionJump([5.0], [Pair{Int, Int}[]], [[1 => 1]])
+    prob = DiscreteProblem([0.0], (0.0, 4.0))
+    jprob = JumpProblem(prob, PureLeaping(), maj; rng)
+
+    @test JumpProcesses.compute_hor([Pair{Int, Int}[], [1 => 2]], 2) == [0, 2]
+
+    for alg in (SimpleExplicitTauLeaping(), SimpleImplicitTauLeaping())
+        sol = solve(jprob, alg; seed = 1234, saveat = 2.0)
+        @test sol.t == [0.0, 2.0, 4.0]
+        @test issorted([u[1] for u in sol.u])   # A can only accumulate
+    end
+
+    # mean of A(t) is the Poisson mean 5t
+    Nsims = 4000
+    sol = solve(EnsembleProblem(jprob), SimpleExplicitTauLeaping(), EnsembleSerial();
+        trajectories = Nsims, saveat = 4.0)
+    @test isapprox(mean(sol.u[i].u[end][1] for i in 1:Nsims), 20.0, rtol = 0.05)
+end
+
 @testset "PureLeaping Aggregator Tests" begin
     # Test with MassActionJump
     u0 = [10, 5, 0]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -58,12 +58,14 @@ end
         @time @safetestset "Spatially Varying Reaction Rates" begin include("spatial/spatial_majump.jl") end
         @time @safetestset "Pure diffusion" begin include("spatial/diffusion.jl") end
         @time @safetestset "SSA kernel on the CPU backend" begin include("kernelabstractions_ssa.jl") end
+        @time @safetestset "Explicit tau-leaping kernel on the CPU backend" begin include("kernelabstractions_explicit_tau.jl") end
     end
 
     if GROUP == "CUDA"
         activate_gpu_env()
         @time @safetestset "GPU Tau Leaping test" begin include("gpu/regular_jumps.jl") end
         @time @safetestset "GPU SSA test" begin include("gpu/ssa.jl") end
+        @time @safetestset "GPU Explicit Tau Leaping test" begin include("gpu/explicit_tau.jl") end
     end
 
     if GROUP == "Correctness"


### PR DESCRIPTION
Runs explicit tau-leaping with one trajectory per GPU thread through `EnsembleGPUKernel`, alongside the existing `SimpleTauLeaping` and `SSAStepper` kernels.

```julia
using JumpProcesses, KernelAbstractions, Adapt, CUDA, Statistics

maj = MassActionJump([0.1 / 1000.0, 0.01],
                     [[1 => 1, 2 => 1], [2 => 1]],
                     [[1 => -1, 2 => 1], [2 => -1, 3 => 1]])
prob = DiscreteProblem([999.0, 10.0, 0.0], (0.0, 250.0))
jump_prob = JumpProblem(prob, PureLeaping(), maj)

sol = solve(EnsembleProblem(jump_prob), SimpleExplicitTauLeaping(),
            EnsembleGPUKernel(CUDABackend()); trajectories = 100_000, saveat = 10.0)

mean(sol.u[i].u[end][3] for i in 1:100_000)
```

## Scope

Mass action jumps only. A `RegularJump` carries arbitrary Julia functions for its rate and its `c`, which a device kernel cannot evaluate, so those problems are rejected with an error that says what to do instead. Callbacks and a `prob_func` are likewise rejected rather than silently ignored.

## How it works

* **Leap selection on the device.** `gpu_compute_gi` mirrors `compute_gi` exactly, and the per-species highest order and largest stoichiometry it needs are precomputed once on the host. `gpu_compute_tau` differs from `compute_tau` only in how the moments are gathered: instead of summing `mu_i` and `sigma_i^2` over a dense stoichiometry matrix, each propensity is evaluated once and scattered through the net stoichiometry, which visits only the nonzeros and needs no propensity cache in global memory. The two agree because the entries the host walks past are zero.
* **Saving.** The leap size adapts to the state, so the number of steps a trajectory takes is not known up front and the solution is sampled onto a fixed `saveat` grid, as the SSA kernel does. `tau` is shortened to land exactly on the next grid point when a step would overshoot it, matching the host solver, so every saved value is a state the trajectory actually occupied rather than an interpolation.
* **Rejection.** A leap that would drive a population negative is rejected and `tau` halved, with the bound carried across iterations so that a retry cannot reproduce the rejected size.
* **No scratch memory.** The state lives in registers as an `SVector`, and the propensities are evaluated twice per step, once to size the leap and once to draw the Poisson counts, so the kernel allocates no per-thread buffers in global memory. Counts come from the backend's device RNG, the same generator the `SimpleTauLeaping` kernel draws from.
* **Shared with the SSA kernel.** The stoichiometry encoding, propensity evaluation, save-grid construction and input validation are reused rather than duplicated. Two of those helpers lose their `ssa` prefix now that both kernels use them.

## Fixes `compute_hor` for zero order reactions

`compute_hor` took its element type from the first entry of the first reaction, `eltype(first(first(reactant_stoch)))`. A zero order reaction has an empty reactant stoichiometry, so that raised `BoundsError: attempt to access 0-element Vector{Pair{Int64, Int64}} at index [1]`. This affected the existing serial `SimpleExplicitTauLeaping` and `SimpleImplicitTauLeaping` as much as the kernel — neither could run a model with a constant-rate influx. The type is now taken from the container type instead, and a regression test covers both serial algorithms.

## Testing

`test/explicit_tau_kernel_tests.jl` holds the assertions and is run twice, against `CUDABackend()` in the `CUDA` group and against KernelAbstractions' `CPU()` in `InterfaceII`, so the kernel is covered by the ordinary test suite as well as by the GPU run.

The reference is the serial `SimpleExplicitTauLeaping` rather than the exact SSA, because tau-leaping carries a discretization bias that the kernel is expected to reproduce. One test pins that bias down instead of ignoring it: it checks the error against the analytic mean shrinks monotonically as `epsilon` tightens (locally 128.5 → 134.0 → 134.8 against an exact 135.3 for `epsilon` of 0.05, 0.01, 0.002). Coverage includes linear death, zero order, SIR, second and third order propensities, a conservation law, extinction, `saveat`/`save_start`/`save_end` handling, and each rejected input.

Verification notes: the CPU backend passes 80/80 locally. The new device arithmetic was also checked on real GPU hardware through Metal, where `gpu_compute_tau` reproduces the host `compute_tau` bit for bit across every `g_i` branch (orders 1 to 3, stoichiometries 1 to 3, and the zero order case). The full kernel cannot run on Metal because `pois_rand` does not compile for that backend — this is pre-existing and not specific to this PR, as master's `SimpleTauLeaping` kernel bus-errors there identically — so end-to-end GPU coverage comes from the CUDA runner.

## Checklist

- [X] Appropriate tests were added
- [X] Any code changes were done in a way that does not break public API
- [X] All documentation related to code changes were updated
- [X] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [X] Any new documentation only uses public API
