### PR TITLE
Report successful completion from CPU tau-leaping solvers

### DIFF
--- a/src/simple_regular_solve.jl
+++ b/src/simple_regular_solve.jl
@@ -374,7 +374,7 @@ function DiffEqBase.solve(jump_prob::JumpProblem, alg::SimpleTauLeaping;
     end
 
     sol = SciMLBase.build_solution(prob, alg, tsave, usave,
-        calculate_error = false,
+        calculate_error = false, retcode = ReturnCode.Success,
         interp = SciMLBase.ConstantInterpolation(tsave, usave))
 end
 
@@ -633,7 +633,7 @@ function DiffEqBase.solve(jump_prob::JumpProblem, alg::SimpleExplicitTauLeaping;
         save_end)
 
     sol = SciMLBase.build_solution(prob, alg, tsave, usave,
-        calculate_error = false,
+        calculate_error = false, retcode = ReturnCode.Success,
         interp = SciMLBase.ConstantInterpolation(tsave, usave))
     return sol
 end
@@ -832,7 +832,7 @@ function DiffEqBase.solve(
 
     sol = SciMLBase.build_solution(
         prob, alg, tsave, usave,
-        calculate_error = false,
+        calculate_error = false, retcode = ReturnCode.Success,
         interp = SciMLBase.ConstantInterpolation(tsave, usave)
     )
     return sol
@@ -1088,7 +1088,7 @@ function DiffEqBase.solve(
 
     sol = SciMLBase.build_solution(
         prob, alg, tsave, usave,
-        calculate_error = false,
+        calculate_error = false, retcode = ReturnCode.Success,
         interp = SciMLBase.ConstantInterpolation(tsave, usave)
     )
     return sol

--- a/test/regular_jumps.jl
+++ b/test/regular_jumps.jl
@@ -3,6 +3,28 @@ using Test, LinearAlgebra, Statistics
 using StableRNGs
 rng = StableRNG(12345)
 
+@testset "Successful leaping return codes" begin
+    prob = DiscreteProblem([100.0], (0.0, 1.0))
+    rate! = (out, u, p, t) -> (out[1] = 0.1 * u[1])
+    change! = (du, u, p, t, counts, mark) -> (du[1] = -counts[1])
+    regular_jump = RegularJump(rate!, change!, 1)
+    massaction_jump = MassActionJump([0.1], [[1 => 1]], [[1 => -1]])
+    for alg in (
+            SimpleTauLeaping(), SimpleExplicitTauLeaping(),
+            SimpleImplicitTauLeaping(), SimpleTrapezoidalLeaping(), SimpleAdaptiveTauLeaping(),
+        )
+        @testset "$(nameof(typeof(alg)))" begin
+            jump = alg isa SimpleTauLeaping ? regular_jump : massaction_jump
+            jp = JumpProblem(prob, PureLeaping(), jump; rng = StableRNG(12345))
+            kwargs = alg isa SimpleTauLeaping ? (; dt = 0.01) : (;)
+            sol = solve(jp, alg; kwargs...)
+            @test sol.t[end] == last(prob.tspan)
+            @test sol.retcode == ReturnCode.Success
+            @test successful_retcode(sol)
+        end
+    end
+end
+
 @test SimpleImplicitTauLeaping().epsilon == 0.05
 @test SimpleTrapezoidalLeaping().epsilon == 0.05
 


### PR DESCRIPTION
Ignore this PR until reviewed by @ChrisRackauckas.

CPU tau-leaping solutions currently retain `ReturnCode.Default` after reaching the final time, so `successful_retcode(sol)` incorrectly returns false. Set `ReturnCode.Success` when the four solver implementations finish normally; the shared implicit implementation covers both implicit and trapezoidal leaping. A looped regression checks final time, exact return code, and the public success predicate for all five algorithms.

### Failing before / passing after

On unmodified master `796ba494`, with only the new official test added:

```sh
julia +1.10.12 --project=tau-retcode-env -e 'include("tau-retcode/test/regular_jumps.jl")'
```

```text
Successful leaping return codes | 5 passed, 10 failed, 15 total
SimpleTauLeaping               | 1 passed, 2 failed
SimpleExplicitTauLeaping       | 1 passed, 2 failed
SimpleImplicitTauLeaping       | 1 passed, 2 failed
SimpleTrapezoidalLeaping       | 1 passed, 2 failed
SimpleAdaptiveTauLeaping       | 1 passed, 2 failed
```

Each solution reached the final time but reported `ReturnCode.Default`. With the four success keywords applied, the same command exited zero:

```text
Successful leaping return codes | 15 passed, 15 total
```

The complete official `test/regular_jumps.jl` file exited zero using a local validation environment with the package and existing test dependencies. Its containing InterfaceI testset passed 88/88 assertions (including two top-level assertions omitted from the standalone printed summaries).

### Source history

Pickaxe and parent-source inspection trace the original missing status keyword to the introduction of `SimpleTauLeaping` in https://github.com/SciML/JumpProcesses.jl/commit/8df9fb662e5c0ea19699622b3c6122e881ef059e. The other implementations also omit it. This is source-history evidence; I did not rerun the historical code against its old dependency environment.

### Validation

```sh
GROUP=InterfaceI julia +1.10.12 --project=tau-retcode -e 'using Pkg; Pkg.test()'
GROUP=QA julia +1.10.12 --project=tau-retcode -e 'using Pkg; Pkg.test()'
julia +1.10.12 --project=tau-retcode/docs tau-retcode/docs/make.jl
```

```text
InterfaceI: 911/911 assertions passed
Testing JumpProcesses tests passed
QA Tests | 18 passed, 18 total
Testing JumpProcesses tests passed
[ Info: HTMLWriter: rendering HTML pages.
```

All commands exited zero. The docs build retained strict checks and link checking; local deployment was skipped by Documenter. Runic checks passed on the changed Julia lines (avoiding unrelated formatting), `typos --config tau-retcode/_typos.toml tau-retcode/src/simple_regular_solve.jl tau-retcode/test/regular_jumps.jl` passed, and `git diff --check` passed.

All 12 CI checks passed on this commit, including GPU, documentation, downgrade, and LTS/release/prerelease interface tests. The final test logs confirm `Tau Leaping Tests | 88 / 88` on all three Julia versions: https://github.com/SciML/JumpProcesses.jl/actions/runs/33965531111.

GPU and downstream jobs were not run locally. No solver timesteps, random sampling, tolerances, or failure handling are changed.

🤖 Generated with Codex CLI 0.153.4 (model: gpt-6-astra; local session ID: 01a070e6-21f2-7dd3-bf52-2ddaf108ac53).
