### PR TITLE
Preserve native mass-action data for tau-leaping solvers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,6 @@
+# Jump representations
+
+Preserve `MassActionJump` in `JumpProblem`. Each solver owns any conversion or
+specialization of reaction data. Do not normalize mass-action jumps into
+`RegularJump` in the problem constructor; keep general-rate support as a separate
+solver path.

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "JumpProcesses"
 uuid = "ccbc3e58-028d-4f4c-8cd5-9ae44345cda5"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "9.32.3"
+version = "9.33.0"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/docs/src/jump_solve.md
+++ b/docs/src/jump_solve.md
@@ -15,7 +15,9 @@ faster as they only simulate the total number of jumps over each leap interval,
 and thus do not need to simulate the realization of every single jump. Jumps for
 use with exact simulation methods can be defined as `ConstantRateJump`s,
 `MassActionJump`s, and/or `VariableRateJump`. Jumps for use with inexact
-τ-leaping methods should be defined as `RegularJump`s.
+τ-leaping methods can be defined as `MassActionJump`s with `PureLeaping()`.
+`SimpleTauLeaping` and StochasticDiffEq's leaping algorithms also accept
+`RegularJump`s for more general rates and count-based updates.
 
 There are special algorithms available for efficiently simulating an exact, pure
 `JumpProblem` (i.e., a `JumpProblem` over a `DiscreteProblem`).  `SSAStepper()`
@@ -71,10 +73,17 @@ These methods support mixing with event handling, other jump types, and all of
 the features of the normal differential equation solvers.
 
   - `TauLeaping`: an adaptive tau-leaping algorithm with post-leap estimates.
+  - `CaoTauLeaping`: adaptive Cao tau selection.
+  - `ImplicitTauLeaping`: implicit tau-leaping.
+  - `ThetaTrapezoidalTauLeaping`: implicit theta-trapezoidal tau-leaping.
+
+All four also accept `JumpProblem(prob, PureLeaping(), mass_action_jump)` directly.
+For fixed steps with the implicit methods, pass `dt` and `adaptive = false`.
 
 ### JumpProcesses.jl
 
-  - `SimpleTauLeaping`: a tau-leaping algorithm for pure `RegularJump` `JumpProblem`s.
+  - `SimpleTauLeaping`: fixed-step leaping for pure `MassActionJump` or `RegularJump`
+    `JumpProblem`s constructed with `PureLeaping()`.
     Requires a choice of `dt`.
   - `RegularSSA`: a version of SSA for pure `RegularJump` `JumpProblem`s.
 
@@ -87,3 +96,31 @@ and the jump process has designed a regular jump.
 
   - `EM`: Explicit Euler-Maruyama.
   - `ImplicitEM`: Implicit Euler-Maruyama. See the SDE solvers page for more details.
+
+## Common mass-action input
+
+The same mass-action problem can be used with JumpProcesses' fixed-step, adaptive
+explicit, implicit, trapezoidal, and switching solvers, as well as
+StochasticDiffEq's leaping solvers:
+
+```@example common_massaction
+using JumpProcesses, StochasticDiffEq
+
+maj = MassActionJump([0.1], [[1 => 1]], [[1 => -1, 2 => 1]])
+prob = DiscreteProblem([1000.0, 0.0], (0.0, 1.0))
+jprob = JumpProblem(prob, PureLeaping(), maj)
+
+fixed_sol = solve(jprob, SimpleTauLeaping(); dt = 0.01)
+explicit_sol = solve(jprob, SimpleExplicitTauLeaping())
+implicit_sol = solve(jprob, SimpleImplicitTauLeaping())
+trapezoidal_sol = solve(jprob, SimpleTrapezoidalLeaping())
+switching_sol = solve(jprob, SimpleAdaptiveTauLeaping())
+regular_sol = solve(jprob, TauLeaping())
+nothing # hide
+```
+
+`SimpleTauLeaping` and `SimpleExplicitTauLeaping` support this mass-action input
+with `EnsembleGPUKernel`. The fixed-step kernel requires `dt`; the adaptive
+explicit kernel requires `saveat`. Implicit and switching GPU kernels are not
+provided. `SimpleTauLeaping` also supports device-compatible `RegularJump`
+functions; the adaptive explicit GPU kernel requires mass-action kinetics.

--- a/docs/src/jump_solve.md
+++ b/docs/src/jump_solve.md
@@ -15,7 +15,8 @@ faster as they only simulate the total number of jumps over each leap interval,
 and thus do not need to simulate the realization of every single jump. Jumps for
 use with exact simulation methods can be defined as `ConstantRateJump`s,
 `MassActionJump`s, and/or `VariableRateJump`. Jumps for use with inexact
-τ-leaping methods can be defined as `MassActionJump`s with `PureLeaping()`.
+JumpProcesses τ-leaping methods can be defined as `MassActionJump`s with
+`PureLeaping()`.
 `SimpleTauLeaping` and StochasticDiffEq's leaping algorithms also accept
 `RegularJump`s for more general rates and count-based updates.
 
@@ -73,11 +74,10 @@ These methods support mixing with event handling, other jump types, and all of
 the features of the normal differential equation solvers.
 
   - `TauLeaping`: an adaptive tau-leaping algorithm with post-leap estimates.
-  - `CaoTauLeaping`: adaptive Cao tau selection.
+  - `CaoTauLeaping`: use fixed steps (`dt`, `adaptive = false`); its adaptive step selector is incomplete.
   - `ImplicitTauLeaping`: implicit tau-leaping.
   - `ThetaTrapezoidalTauLeaping`: implicit theta-trapezoidal tau-leaping.
 
-All four also accept `JumpProblem(prob, PureLeaping(), mass_action_jump)` directly.
 For fixed steps with the implicit methods, pass `dt` and `adaptive = false`.
 
 ### JumpProcesses.jl
@@ -100,11 +100,10 @@ and the jump process has designed a regular jump.
 ## Common mass-action input
 
 The same mass-action problem can be used with JumpProcesses' fixed-step, adaptive
-explicit, implicit, trapezoidal, and switching solvers, as well as
-StochasticDiffEq's leaping solvers:
+explicit, implicit, trapezoidal, and switching solvers:
 
 ```@example common_massaction
-using JumpProcesses, StochasticDiffEq
+using JumpProcesses
 
 maj = MassActionJump([0.1], [[1 => 1]], [[1 => -1, 2 => 1]])
 prob = DiscreteProblem([1000.0, 0.0], (0.0, 1.0))
@@ -115,7 +114,6 @@ explicit_sol = solve(jprob, SimpleExplicitTauLeaping())
 implicit_sol = solve(jprob, SimpleImplicitTauLeaping())
 trapezoidal_sol = solve(jprob, SimpleTrapezoidalLeaping())
 switching_sol = solve(jprob, SimpleAdaptiveTauLeaping())
-regular_sol = solve(jprob, TauLeaping())
 nothing # hide
 ```
 

--- a/docs/src/jump_types.md
+++ b/docs/src/jump_types.md
@@ -494,3 +494,16 @@ as will trying to update either `p` or `tspan` while passing a new
     COEVOLVE: a joint point process model for information diffusion and network
     evolution, Journal of Machine Learning Research 18(1), 1305–1353 (2017). doi:
     10.5555/3122009.3122050.
+
+## Mass-action operations for solver authors
+
+`JumpProblem` preserves `MassActionJump` data. Solvers can use the rate constants
+and stoichiometry directly and choose their own storage and evaluation strategy.
+The following operations support CPU solver implementations; GPU solvers should
+prepare a device-compatible representation during solver initialization.
+
+```@docs
+massaction_rates!
+massaction_stoichiometry_mul!
+massaction_drift!
+```

--- a/ext/JumpProcessesKernelAbstractionsExt.jl
+++ b/ext/JumpProcessesKernelAbstractionsExt.jl
@@ -27,7 +27,7 @@ function SciMLBase.__solve(ensembleprob::SciMLBase.AbstractEnsembleProblem,
 
     # Validate that this is a PureLeaping JumpProblem
     JumpProcesses.validate_pure_leaping_inputs(jump_prob, alg) ||
-        error("SimpleTauLeaping can only be used with PureLeaping JumpProblems with only non-RegularJumps.")
+        error("SimpleTauLeaping requires a PureLeaping JumpProblem with a MassActionJump or a RegularJump.")
     prob = jump_prob.prob
 
     probs = [remake(jump_prob) for _ in 1:trajectories]
@@ -79,6 +79,36 @@ struct JumpData{R, C}
     rate::R
     c::C
     numjumps::Int
+end
+
+Adapt.@adapt_structure JumpData
+
+struct GPUMassActionRate{M}
+    jump::M
+end
+Adapt.@adapt_structure GPUMassActionRate
+
+function (rate::GPUMassActionRate)(out, u, p, t)
+    for j in eachindex(out)
+        out[j] = gpu_evalrxrate(u, j, rate.jump, eltype(out))
+    end
+    return nothing
+end
+
+struct GPUMassActionChange{M}
+    jump::M
+end
+Adapt.@adapt_structure GPUMassActionChange
+
+function (change::GPUMassActionChange)(du, u, p, t, counts, mark)
+    fill!(du, zero(eltype(du)))
+    maj = change.jump
+    for j in eachindex(counts)
+        for k in maj.ns_offsets[j]:(maj.ns_offsets[j + 1] - 1)
+            du[maj.ns_species[k]] += maj.ns_coeffs[k] * counts[j]
+        end
+    end
+    return nothing
 end
 
 # SimpleTauLeaping kernel
@@ -155,7 +185,12 @@ function vectorized_solve(probs, prob::JumpProblem, alg::SimpleTauLeaping;
         backend, trajectories, seed, dt, kwargs...)
     # Extract common jump data
     rj = prob.regular_jump
-    rj_data = JumpData(rj.rate, rj.c, rj.numjumps)
+    rj_data = if JumpProcesses.is_massaction_regular_jump(rj, prob.massaction_jump)
+        maj = GPUMassActionJump(prob.massaction_jump, backend, float(eltype(prob.prob.tspan)))
+        JumpData(GPUMassActionRate(maj), GPUMassActionChange(maj), rj.numjumps)
+    else
+        JumpData(rj.rate, rj.c, rj.numjumps)
+    end
 
     # Extract trajectory-specific data without static typing
     probs_data = [TrajectoryData(SA{eltype(p.prob.u0)}[p.prob.u0...], p.prob.p, p.prob.tspan)
@@ -183,7 +218,7 @@ function vectorized_solve(probs, prob::JumpProblem, alg::SimpleTauLeaping;
 
     # Pre-allocate thread-local buffers
     current_u_buf = allocate(backend, eltype(prob.prob.u0), (state_dim, n_trajectories))
-    rate_cache_buf = allocate(backend, eltype(prob.prob.u0), (num_jumps, n_trajectories))
+    rate_cache_buf = allocate(backend, float(eltype(prob.prob.u0)), (num_jumps, n_trajectories))
     counts_buf = allocate(backend, eltype(prob.prob.u0), (num_jumps, n_trajectories))
     local_dc_buf = allocate(backend, eltype(prob.prob.u0), (state_dim, n_trajectories))
 

--- a/ext/JumpProcessesKernelAbstractionsExt.jl
+++ b/ext/JumpProcessesKernelAbstractionsExt.jl
@@ -83,29 +83,23 @@ end
 
 Adapt.@adapt_structure JumpData
 
-struct GPUMassActionRate{M}
-    jump::M
-end
-Adapt.@adapt_structure GPUMassActionRate
+gpu_num_jumps(jump::JumpData) = jump.numjumps
+leaping_rates!(out, jump::JumpData, u, p, t) = jump.rate(out, u, p, t)
+leaping_change!(du, jump::JumpData, u, p, t, counts) =
+    jump.c(du, u, p, t, counts, nothing)
 
-function (rate::GPUMassActionRate)(out, u, p, t)
+function leaping_rates!(out, jump::GPUMassActionJump, u, p, t)
     for j in eachindex(out)
-        out[j] = gpu_evalrxrate(u, j, rate.jump, eltype(out))
+        out[j] = gpu_evalrxrate(u, j, jump, eltype(out))
     end
     return nothing
 end
 
-struct GPUMassActionChange{M}
-    jump::M
-end
-Adapt.@adapt_structure GPUMassActionChange
-
-function (change::GPUMassActionChange)(du, u, p, t, counts, mark)
+function leaping_change!(du, jump::GPUMassActionJump, u, p, t, counts)
     fill!(du, zero(eltype(du)))
-    maj = change.jump
     for j in eachindex(counts)
-        for k in maj.ns_offsets[j]:(maj.ns_offsets[j + 1] - 1)
-            du[maj.ns_species[k]] += maj.ns_coeffs[k] * counts[j]
+        for k in jump.ns_offsets[j]:(jump.ns_offsets[j + 1] - 1)
+            du[jump.ns_species[k]] += jump.ns_coeffs[k] * counts[j]
         end
     end
     return nothing
@@ -133,9 +127,7 @@ end
     tspan = prob_data.tspan
 
     # Extract jump data
-    rate = rj_data.rate
-    num_jumps = rj_data.numjumps
-    c = rj_data.c
+    num_jumps = gpu_num_jumps(rj_data)
 
     # Initialize current_u from u0
     @inbounds for k in 1:length(u0)
@@ -160,7 +152,7 @@ end
         tprev = tspan[1] + (j-2) * dt
 
         # Compute rates and scale by dt
-        rate(rate_cache, current_u, p, tprev)
+        leaping_rates!(rate_cache, rj_data, current_u, p, tprev)
         rate_cache .*= dt
 
         # Poisson sampling
@@ -169,7 +161,7 @@ end
         end
 
         # Apply changes
-        c(local_dc, current_u, p, tprev, counts, nothing)
+        leaping_change!(local_dc, rj_data, current_u, p, tprev, counts)
         current_u .+= local_dc
 
         # Store results
@@ -185,9 +177,8 @@ function vectorized_solve(probs, prob::JumpProblem, alg::SimpleTauLeaping;
         backend, trajectories, seed, dt, kwargs...)
     # Extract common jump data
     rj = prob.regular_jump
-    rj_data = if JumpProcesses.is_massaction_regular_jump(rj, prob.massaction_jump)
-        maj = GPUMassActionJump(prob.massaction_jump, backend, float(eltype(prob.prob.tspan)))
-        JumpData(GPUMassActionRate(maj), GPUMassActionChange(maj), rj.numjumps)
+    rj_data = if rj === nothing
+        GPUMassActionJump(prob.massaction_jump, backend, float(eltype(prob.prob.tspan)))
     else
         JumpData(rj.rate, rj.c, rj.numjumps)
     end
@@ -206,7 +197,7 @@ function vectorized_solve(probs, prob::JumpProblem, alg::SimpleTauLeaping;
     dt = Float64(dt)
     n_steps = Int((tspan[2] - tspan[1]) / dt) + 1
     n_trajectories = length(probs)
-    num_jumps = rj_data.numjumps
+    num_jumps = gpu_num_jumps(rj_data)
 
     # Validate dimensions
     @assert state_dim > 0 "Dimension of state must be positive"

--- a/ext/ssa_stepper.jl
+++ b/ext/ssa_stepper.jl
@@ -221,7 +221,11 @@ function validate_gpu_massaction_inputs(jump_prob::JumpProblem)
         JumpProcesses.get_num_majumps(jump_prob.massaction_jump) > 0 &&
         isempty(jump_prob.constant_jumps) &&
         isempty(jump_prob.variable_jumps) &&
-        jump_prob.regular_jump === nothing &&
+        (
+        jump_prob.regular_jump === nothing || JumpProcesses.is_massaction_regular_jump(
+            jump_prob.regular_jump, jump_prob.massaction_jump
+        )
+    ) &&
         isempty(jump_prob.jump_callback.continuous_callbacks) &&
         length(jump_prob.jump_callback.discrete_callbacks) <= 1
 end

--- a/ext/ssa_stepper.jl
+++ b/ext/ssa_stepper.jl
@@ -221,11 +221,7 @@ function validate_gpu_massaction_inputs(jump_prob::JumpProblem)
         JumpProcesses.get_num_majumps(jump_prob.massaction_jump) > 0 &&
         isempty(jump_prob.constant_jumps) &&
         isempty(jump_prob.variable_jumps) &&
-        (
-        jump_prob.regular_jump === nothing || JumpProcesses.is_massaction_regular_jump(
-            jump_prob.regular_jump, jump_prob.massaction_jump
-        )
-    ) &&
+        jump_prob.regular_jump === nothing &&
         isempty(jump_prob.jump_callback.continuous_callbacks) &&
         length(jump_prob.jump_callback.discrete_callbacks) <= 1
 end

--- a/src/JumpProcesses.jl
+++ b/src/JumpProcesses.jl
@@ -139,6 +139,11 @@ problem construction.
 
   - `PureLeaping` is currently intended for tau-leaping algorithms such as
     [`SimpleTauLeaping`](@ref) and [`SimpleExplicitTauLeaping`](@ref).
+  - A `MassActionJump` can be passed directly to all tau-leaping algorithms in
+    JumpProcesses and StochasticDiffEq. The rates and count-based updates are
+    supplied automatically; no user-written `RegularJump` is required.
+  - `SimpleTauLeaping` and StochasticDiffEq's leaping algorithms additionally accept
+    a `RegularJump` for more general rates and updates.
   - Spatial jump problems are not supported by the `PureLeaping` construction path.
 
 ## Examples

--- a/src/JumpProcesses.jl
+++ b/src/JumpProcesses.jl
@@ -71,6 +71,7 @@ const USE_SORTINGDIRECT_THRESHOLD = 200
 
 include("jumps.jl")
 export ConstantRateJump, VariableRateJump, RegularJump, MassActionJump, JumpSet
+export massaction_rates!, massaction_stoichiometry_mul!, massaction_drift!
 
 include("massaction_rates.jl")
 
@@ -140,10 +141,10 @@ problem construction.
   - `PureLeaping` is currently intended for tau-leaping algorithms such as
     [`SimpleTauLeaping`](@ref) and [`SimpleExplicitTauLeaping`](@ref).
   - A `MassActionJump` can be passed directly to all tau-leaping algorithms in
-    JumpProcesses and StochasticDiffEq. The rates and count-based updates are
-    supplied automatically; no user-written `RegularJump` is required.
-  - `SimpleTauLeaping` and StochasticDiffEq's leaping algorithms additionally accept
-    a `RegularJump` for more general rates and updates.
+    JumpProcesses. The problem preserves its mass-action
+    representation so each solver can use the rate constants and stoichiometry directly.
+  - `SimpleTauLeaping` additionally accepts a `RegularJump` for more general rates
+    and updates.
   - Spatial jump problems are not supported by the `PureLeaping` construction path.
 
 ## Examples

--- a/src/massaction_rates.jl
+++ b/src/massaction_rates.jl
@@ -158,3 +158,39 @@ function add_self_dependencies!(dg; dosort = true)
         end
     end
 end
+
+struct MassActionRate{M}
+    jump::M
+end
+
+function (rate::MassActionRate)(out, u, p, t)
+    for j in eachindex(out)
+        out[j] = evalrxrate(u, j, rate.jump)
+    end
+    return nothing
+end
+
+struct MassActionChange{M}
+    jump::M
+end
+
+function (change::MassActionChange)(du, u, p, t, counts, mark)
+    fill!(du, zero(eltype(du)))
+    for j in eachindex(counts)
+        for (species, coefficient) in change.jump.net_stoch[j]
+            du[species] += coefficient * counts[j]
+        end
+    end
+    return nothing
+end
+
+function massaction_regular_jump(maj::MassActionJump)
+    return RegularJump{true}(MassActionRate(maj), MassActionChange(maj), get_num_majumps(maj))
+end
+
+is_massaction_regular_jump(::Any, maj) = false
+function is_massaction_regular_jump(
+        rj::RegularJump{true, <:MassActionRate, <:MassActionChange}, maj
+    )
+    return rj.rate.jump === maj && rj.c.jump === maj
+end

--- a/src/massaction_rates.jl
+++ b/src/massaction_rates.jl
@@ -159,38 +159,87 @@ function add_self_dependencies!(dg; dosort = true)
     end
 end
 
-struct MassActionRate{M}
-    jump::M
-end
+@inline massaction_data(jump::MassActionJump) =
+    (jump.scaled_rates, jump.reactant_stoch, jump.net_stoch)
+@inline massaction_data(jump::MassActionJump{<:Number}) =
+    ((jump.scaled_rates,), (jump.reactant_stoch,), (jump.net_stoch,))
 
-function (rate::MassActionRate)(out, u, p, t)
-    for j in eachindex(out)
-        out[j] = evalrxrate(u, j, rate.jump)
+"""
+    massaction_rates!(rates, jump::MassActionJump, u)
+
+Write each reaction propensity at populations `u` into `rates`. Uses the stored,
+combinatorially scaled rate constants and falling factorial rate laws. A reaction
+with insufficient reactants has zero propensity. `rates` must have one entry per
+reaction and must not alias `u` or the jump's data. Rate constants must already
+be initialized; for parameter-dependent rates, use the mass-action jump stored
+in a `JumpProblem`.
+"""
+function massaction_rates!(rates, jump::MassActionJump, u)
+    constants, reactants, _ = massaction_data(jump)
+    for j in eachindex(constants)
+        rates[j] = massaction_propensity(constants, reactants, u, j)
     end
-    return nothing
+    return rates
 end
 
-struct MassActionChange{M}
-    jump::M
+@inline function massaction_propensity(constants, reactants, u, j)
+    rate = one(eltype(u))
+    for (species, order) in reactants[j]
+        population = u[species]
+        population <= order - 1 && return zero(rate)
+        for k in 0:(order - 1)
+            rate *= population - k
+        end
+    end
+    return rate * constants[j]
 end
 
-function (change::MassActionChange)(du, u, p, t, counts, mark)
+"""
+    massaction_stoichiometry_mul!(du, jump::MassActionJump, counts)
+
+Overwrite `du` with the net stoichiometry times the reaction vector `counts`.
+`counts` may contain reaction counts or propensities and must have one entry per
+reaction. `du` must have one entry per species and must not alias `counts` or the
+jump's data.
+"""
+function massaction_stoichiometry_mul!(du, jump::MassActionJump, counts)
     fill!(du, zero(eltype(du)))
-    for j in eachindex(counts)
-        for (species, coefficient) in change.jump.net_stoch[j]
+    _, _, stoichiometry = massaction_data(jump)
+    for j in eachindex(stoichiometry)
+        for (species, coefficient) in stoichiometry[j]
             du[species] += coefficient * counts[j]
         end
     end
-    return nothing
+    return du
 end
 
-function massaction_regular_jump(maj::MassActionJump)
-    return RegularJump{true}(MassActionRate(maj), MassActionChange(maj), get_num_majumps(maj))
+"""
+    massaction_drift!(du, jump::MassActionJump, u)
+
+Overwrite `du` with the mass-action drift, the net stoichiometry times the
+propensities at `u`. Evaluates and accumulates each reaction without allocating
+an intermediate propensity vector. Supports automatic differentiation through
+`u` when `du` can store the resulting scalar type. `du` must have one entry per
+species and must not alias `u` or the jump's data. Initialize rate constants as
+for [`massaction_rates!`](@ref).
+"""
+function massaction_drift!(du, jump::MassActionJump, u)
+    fill!(du, zero(eltype(du)))
+    constants, reactants, stoichiometry = massaction_data(jump)
+    for j in eachindex(constants)
+        rate = massaction_propensity(constants, reactants, u, j)
+        for (species, coefficient) in stoichiometry[j]
+            du[species] += coefficient * rate
+        end
+    end
+    return du
 end
 
-is_massaction_regular_jump(::Any, maj) = false
-function is_massaction_regular_jump(
-        rj::RegularJump{true, <:MassActionRate, <:MassActionChange}, maj
-    )
-    return rj.rate.jump === maj && rj.c.jump === maj
-end
+leaping_rates!(out, jump::MassActionJump, u, p, t) = massaction_rates!(out, jump, u)
+leaping_rates!(out, jump::RegularJump, u, p, t) = jump.rate(out, u, p, t)
+leaping_change!(du, jump::MassActionJump, u, p, t, counts, mark) =
+    massaction_stoichiometry_mul!(du, jump, counts)
+leaping_change!(du, jump::RegularJump, u, p, t, counts, mark) =
+    jump.c(du, u, p, t, counts, mark)
+leaping_num_jumps(jump::MassActionJump) = get_num_majumps(jump)
+leaping_num_jumps(jump::RegularJump) = jump.numjumps

--- a/src/problem.jl
+++ b/src/problem.jl
@@ -350,13 +350,18 @@ function JumpProblem(prob, aggregator::PureLeaping, jumps::JumpSet;
     crjs = jumps.constant_jumps
     vrjs = jumps.variable_jumps
     
-    iip = isinplace_jump(prob, jumps.regular_jump)
+    rj = jumps.regular_jump
+    if rj === nothing && prob isa DiscreteProblem && get_num_majumps(maj) > 0
+        rj = massaction_regular_jump(maj)
+    end
+    iip = isinplace_jump(prob, rj)
     solkwargs = tstops === nothing ? make_kwarg(; callback) : make_kwarg(; callback, tstops)
 
     JumpProblem{iip, typeof(prob), typeof(aggregator), typeof(jump_cbs),
-        typeof(disc_agg), typeof(crjs), typeof(vrjs), typeof(jumps.regular_jump),
+        typeof(disc_agg), typeof(crjs), typeof(vrjs), typeof(rj),
         typeof(maj), typeof(rng), typeof(solkwargs)}(prob, aggregator, disc_agg,
-        jump_cbs, crjs, vrjs, jumps.regular_jump, maj, rng, solkwargs)
+        jump_cbs, crjs, vrjs, rj, maj, rng, solkwargs
+    )
 end
 
 aggregator(jp::JumpProblem{iip, P, A}) where {iip, P, A} = A

--- a/src/problem.jl
+++ b/src/problem.jl
@@ -351,9 +351,6 @@ function JumpProblem(prob, aggregator::PureLeaping, jumps::JumpSet;
     vrjs = jumps.variable_jumps
     
     rj = jumps.regular_jump
-    if rj === nothing && prob isa DiscreteProblem && get_num_majumps(maj) > 0
-        rj = massaction_regular_jump(maj)
-    end
     iip = isinplace_jump(prob, rj)
     solkwargs = tstops === nothing ? make_kwarg(; callback) : make_kwarg(; callback, tstops)
 

--- a/src/simple_regular_solve.jl
+++ b/src/simple_regular_solve.jl
@@ -1,10 +1,13 @@
 """
     SimpleTauLeaping()
 
-Fixed-step tau-leaping algorithm for pure [`RegularJump`](@ref) problems.
+Fixed-step tau-leaping algorithm for pure [`MassActionJump`](@ref) or
+[`RegularJump`](@ref) problems.
 
-Use `SimpleTauLeaping` with `JumpProblem(prob, PureLeaping(), regular_jump)` and pass
-the timestep through the `dt` keyword to `solve`.
+Use `SimpleTauLeaping` with `JumpProblem(prob, PureLeaping(), jump)`, where `jump` is
+a `MassActionJump` or a `RegularJump`, and pass the timestep through `dt` to `solve`.
+Both representations also support `EnsembleGPUKernel`; custom regular-jump rate
+and update functions must be compatible with the selected device.
 
 ## Keyword Arguments
 
@@ -241,7 +244,10 @@ function validate_pure_leaping_inputs(jump_prob::JumpProblem, alg)
         isempty(jump_prob.jump_callback.discrete_callbacks) &&
         isempty(jump_prob.constant_jumps) &&
         isempty(jump_prob.variable_jumps) &&
-        get_num_majumps(jump_prob.massaction_jump) == 0 &&
+        (
+        get_num_majumps(jump_prob.massaction_jump) == 0 ||
+            is_massaction_regular_jump(jump_prob.regular_jump, jump_prob.massaction_jump)
+    ) &&
         jump_prob.regular_jump !== nothing
 end
 
@@ -304,7 +310,7 @@ function DiffEqBase.solve(jump_prob::JumpProblem, alg::SimpleTauLeaping;
         seed = nothing, dt = error("dt is required for SimpleTauLeaping."),
         saveat = nothing, save_start = nothing, save_end = nothing)
     validate_pure_leaping_inputs(jump_prob, alg) ||
-        error("SimpleTauLeaping can only be used with PureLeaping JumpProblems with only RegularJumps.")
+        error("SimpleTauLeaping requires a PureLeaping JumpProblem with a MassActionJump or a RegularJump.")
 
     (; prob, rng) = jump_prob
     (seed !== nothing) && seed!(rng, seed)

--- a/src/simple_regular_solve.jl
+++ b/src/simple_regular_solve.jl
@@ -240,15 +240,15 @@ function validate_pure_leaping_inputs(jump_prob::JumpProblem, alg)
         JumpProblem, i.e. call JumpProblem(::DiscreteProblem, PureLeaping(),...). \
         Passing $(jump_prob.aggregator) is deprecated and will be removed in the next breaking release."
     end
-    isempty(jump_prob.jump_callback.continuous_callbacks) &&
+    return jump_prob.prob isa DiscreteProblem &&
+        isempty(jump_prob.jump_callback.continuous_callbacks) &&
         isempty(jump_prob.jump_callback.discrete_callbacks) &&
         isempty(jump_prob.constant_jumps) &&
         isempty(jump_prob.variable_jumps) &&
-        (
-        get_num_majumps(jump_prob.massaction_jump) == 0 ||
-            is_massaction_regular_jump(jump_prob.regular_jump, jump_prob.massaction_jump)
-    ) &&
+        xor(
+        get_num_majumps(jump_prob.massaction_jump) > 0,
         jump_prob.regular_jump !== nothing
+    )
 end
 
 function validate_pure_leaping_inputs(
@@ -316,11 +316,10 @@ function DiffEqBase.solve(jump_prob::JumpProblem, alg::SimpleTauLeaping;
     (seed !== nothing) && seed!(rng, seed)
 
     rj = jump_prob.regular_jump
-    rate = rj.rate # rate function rate(out,u,p,t)
-    numjumps = rj.numjumps # used for size information (# of jump processes)
-    c = rj.c # matrix-free operator c(u_buffer, uprev, tprev, counts, p, mark)
+    jump = rj === nothing ? jump_prob.massaction_jump : rj
+    numjumps = leaping_num_jumps(jump)
 
-    if !isnothing(rj.mark_dist) == nothing # https://github.com/JuliaDiffEq/DifferentialEquations.jl/issues/250
+    if rj !== nothing && !isnothing(rj.mark_dist)
         error("Mark distributions are currently not supported in SimpleTauLeaping")
     end
 
@@ -352,10 +351,10 @@ function DiffEqBase.solve(jump_prob::JumpProblem, alg::SimpleTauLeaping;
     for i in 2:n
         tprev = tspan[1] + (i - 2) * dt
         t_new = tprev + dt
-        rate(rate_cache, uprev, p, tprev)
+        leaping_rates!(rate_cache, jump, uprev, p, tprev)
         rate_cache .*= dt
         counts .= pois_rand.((rng,), rate_cache)
-        c(du, uprev, p, tprev, counts, mark)
+        leaping_change!(du, jump, uprev, p, tprev, counts, nothing)
         u_new .= du .+ uprev
 
         # Save logic — only allocate (via copy) when actually saving

--- a/test/massaction_fixed_tau_kernel.jl
+++ b/test/massaction_fixed_tau_kernel.jl
@@ -1,0 +1,25 @@
+using JumpProcesses, KernelAbstractions, Adapt, Test, Statistics
+
+function test_massaction_fixed_tau_kernel(backend)
+    return @testset "Fixed-step mass-action kernel ($T)" for T in (Float64, Int)
+        maj = MassActionJump([0.2], [[1 => 1]], [[1 => -1, 2 => 1]])
+        jp = JumpProblem(DiscreteProblem(T[1001, 0], (0.0, 1.0)), PureLeaping(), maj)
+        sol = solve(
+            EnsembleProblem(jp), SimpleTauLeaping(), EnsembleGPUKernel(backend);
+            trajectories = 2000, dt = 0.01
+        )
+        @test length(sol.u) == 2000
+        @test all(s -> successful_retcode(s), sol.u)
+        @test all(s -> s.t[end] ≈ 1.0, sol.u)
+        @test all(s -> all(u -> sum(u) ≈ 1001, s.u), sol.u)
+        @test mean(s.u[end][1] for s in sol.u) ≈ 1001 * (1 - 0.2 * 0.01)^100 rtol = 0.01
+
+        births = MassActionJump([10.0], [Pair{Int, Int}[]], [[1 => 1]])
+        jp = JumpProblem(DiscreteProblem(T[0], (0.0, 1.0)), PureLeaping(), births)
+        sol = solve(
+            EnsembleProblem(jp), SimpleTauLeaping(), EnsembleGPUKernel(backend);
+            trajectories = 2000, dt = 0.01
+        )
+        @test mean(s.u[end][1] for s in sol.u) ≈ 10 rtol = 0.05
+    end
+end

--- a/test/massaction_leaping.jl
+++ b/test/massaction_leaping.jl
@@ -1,0 +1,89 @@
+using JumpProcesses, StochasticDiffEq, Test, StableRNGs
+
+regular_leaping_algs = (
+    SimpleTauLeaping(), TauLeaping(), CaoTauLeaping(),
+    ImplicitTauLeaping(), ThetaTrapezoidalTauLeaping(),
+)
+
+@testset "Mass-action input for regular leaping solvers" begin
+    maj = MassActionJump(
+        [0.02, 0.1], [[1 => 2], [2 => 1]],
+        [[1 => -2, 2 => 1], [1 => 2, 2 => -1]]
+    )
+    prob = DiscreteProblem([40.0, 20.0], (0.0, 0.2))
+    function rate!(out, u, p, t)
+        out[1] = u[1] * max(u[1] - 1, 0) * 0.01
+        out[2] = 0.1 * u[2]
+        nothing
+    end
+    function change!(du, u, p, t, counts, mark)
+        du[1] = -2 * counts[1] + 2 * counts[2]
+        du[2] = counts[1] - counts[2]
+        nothing
+    end
+    rj = RegularJump(rate!, change!, 2)
+    for alg in regular_leaping_algs,
+            adaptive in (alg isa Union{TauLeaping, CaoTauLeaping} ? (false, true) : (false,))
+        @testset "$(nameof(typeof(alg))), adaptive=$adaptive" begin
+            actual = JumpProblem(prob, PureLeaping(), maj; rng = StableRNG(123))
+            reference = JumpProblem(prob, PureLeaping(), rj; rng = StableRNG(123))
+            opts = alg isa SimpleTauLeaping ? (; dt = 0.005, seed = 123) :
+                (; dt = 0.005, seed = 123, adaptive)
+            sol = solve(actual, alg; opts...)
+            ref = solve(reference, alg; opts...)
+            @test successful_retcode(sol)
+            @test sol.t == ref.t
+            @test sol.u == ref.u
+            @test all(u -> u[1] + 2u[2] ≈ 80, sol.u)
+        end
+    end
+end
+
+@testset "Generated mass-action rate and update" begin
+    for scale_rates in (true, false)
+        maj = MassActionJump(
+            [2.0, 6.0], [Pair{Int, Int}[], [1 => 3]],
+            [[1 => 1], [1 => -3, 2 => 1]]; scale_rates
+        )
+        jp = JumpProblem(DiscreteProblem([5.0, 0.0], (0.0, 1.0)), PureLeaping(), maj)
+        out = fill(NaN, 2)
+        jp.regular_jump.rate(out, [5.0, 0.0], nothing, 0.0)
+        @test out == [2.0, scale_rates ? 60.0 : 360.0]
+        jp.regular_jump.rate(out, [1.0, 0.0], nothing, 0.0)
+        @test out == [2.0, 0.0]
+        du = fill(NaN, 2)
+        jp.regular_jump.c(du, [5.0, 0.0], nothing, 0.0, [4.0, 2.0], nothing)
+        @test du == [-2.0, 2.0]
+    end
+    maj = MassActionJump([[1 => 1]], [[1 => -1, 2 => 1]]; param_idxs = [1])
+    jp = JumpProblem(DiscreteProblem([20.0, 0.0], (0.0, 1.0), [0.1]), PureLeaping(), maj)
+    remade = remake(jp; p = [0.3])
+    out = zeros(1)
+    remade.regular_jump.rate(out, remade.prob.u0, remade.prob.p, 0.0)
+    @test out == [6.0]
+    oprob = ODEProblem((du, u, p, t) -> fill!(du, 0), [20.0, 0.0], (0.0, 1.0), [0.1])
+    ojp = JumpProblem(oprob, PureLeaping(), maj)
+    @test ojp.regular_jump === nothing
+    @test_throws ErrorException solve(ojp, SimpleTauLeaping(); dt = 0.01)
+end
+
+@testset "General regular rates remain supported" begin
+    rate!(out, u, p, t) = (out[1] = 100 * u[1] / (1 + u[1]))
+    function change!(du, u, p, t, counts, mark)
+        du[1] = -counts[1]
+        du[2] = counts[1]
+        nothing
+    end
+    jp = JumpProblem(
+        DiscreteProblem([100.0, 0.0], (0.0, 0.1)),
+        PureLeaping(), RegularJump(rate!, change!, 1)
+    )
+    for alg in regular_leaping_algs
+        opts = alg isa SimpleTauLeaping ? (; dt = 0.001, seed = 42) :
+            (; dt = 0.001, seed = 42, adaptive = false)
+        sol = solve(jp, alg; opts...)
+        @test successful_retcode(sol)
+        @test sol.u[end][2] > 0
+        @test all(u -> sum(u) ≈ 100, sol.u)
+    end
+end

--- a/test/massaction_leaping.jl
+++ b/test/massaction_leaping.jl
@@ -1,9 +1,6 @@
-using JumpProcesses, StochasticDiffEq, Test, StableRNGs
+using JumpProcesses, Test, StableRNGs, ForwardDiff
 
-regular_leaping_algs = (
-    SimpleTauLeaping(), TauLeaping(), CaoTauLeaping(),
-    ImplicitTauLeaping(), ThetaTrapezoidalTauLeaping(),
-)
+regular_leaping_algs = (SimpleTauLeaping(),)
 
 @testset "Mass-action input for regular leaping solvers" begin
     maj = MassActionJump(
@@ -23,7 +20,7 @@ regular_leaping_algs = (
     end
     rj = RegularJump(rate!, change!, 2)
     for alg in regular_leaping_algs,
-            adaptive in (alg isa Union{TauLeaping, CaoTauLeaping} ? (false, true) : (false,))
+            adaptive in (false,)
         @testset "$(nameof(typeof(alg))), adaptive=$adaptive" begin
             actual = JumpProblem(prob, PureLeaping(), maj; rng = StableRNG(123))
             reference = JumpProblem(prob, PureLeaping(), rj; rng = StableRNG(123))
@@ -39,28 +36,39 @@ regular_leaping_algs = (
     end
 end
 
-@testset "Generated mass-action rate and update" begin
+@testset "Native mass-action operations" begin
     for scale_rates in (true, false)
         maj = MassActionJump(
             [2.0, 6.0], [Pair{Int, Int}[], [1 => 3]],
             [[1 => 1], [1 => -3, 2 => 1]]; scale_rates
         )
         jp = JumpProblem(DiscreteProblem([5.0, 0.0], (0.0, 1.0)), PureLeaping(), maj)
+        @test jp.regular_jump === nothing
         out = fill(NaN, 2)
-        jp.regular_jump.rate(out, [5.0, 0.0], nothing, 0.0)
+        massaction_rates!(out, jp.massaction_jump, [5.0, 0.0])
         @test out == [2.0, scale_rates ? 60.0 : 360.0]
-        jp.regular_jump.rate(out, [1.0, 0.0], nothing, 0.0)
+        massaction_rates!(out, jp.massaction_jump, [1.0, 0.0])
         @test out == [2.0, 0.0]
         du = fill(NaN, 2)
-        jp.regular_jump.c(du, [5.0, 0.0], nothing, 0.0, [4.0, 2.0], nothing)
+        massaction_stoichiometry_mul!(du, jp.massaction_jump, [4.0, 2.0])
         @test du == [-2.0, 2.0]
+        u = [5.0, 0.0]
+        massaction_rates!(out, jp.massaction_jump, u)
+        massaction_stoichiometry_mul!(du, jp.massaction_jump, out)
+        @test massaction_drift!(zeros(2), jp.massaction_jump, u) == du
+        jac = ForwardDiff.jacobian(u) do x
+            massaction_drift!(similar(x), jp.massaction_jump, x)
+        end
+        factor = scale_rates ? 1.0 : 6.0
+        @test jac == [-141.0factor 0.0; 47.0factor 0.0]
     end
     maj = MassActionJump([[1 => 1]], [[1 => -1, 2 => 1]]; param_idxs = [1])
     jp = JumpProblem(DiscreteProblem([20.0, 0.0], (0.0, 1.0), [0.1]), PureLeaping(), maj)
     remade = remake(jp; p = [0.3])
     out = zeros(1)
-    remade.regular_jump.rate(out, remade.prob.u0, remade.prob.p, 0.0)
+    massaction_rates!(out, remade.massaction_jump, remade.prob.u0)
     @test out == [6.0]
+    @test remade.regular_jump === nothing
     oprob = ODEProblem((du, u, p, t) -> fill!(du, 0), [20.0, 0.0], (0.0, 1.0), [0.1])
     ojp = JumpProblem(oprob, PureLeaping(), maj)
     @test ojp.regular_jump === nothing
@@ -85,5 +93,20 @@ end
         @test successful_retcode(sol)
         @test sol.u[end][2] > 0
         @test all(u -> sum(u) ≈ 100, sol.u)
+    end
+end
+
+@testset "Single-reaction mass-action operations" begin
+    for (rate, reactants, net) in (
+            (6.0, [1 => 3], [1 => -3, 2 => 1]),
+            (2.0, Pair{Int, Int}[], [1 => 1]),
+        )
+        single = MassActionJump(rate, reactants, net)
+        vector = MassActionJump([rate], [reactants], [net])
+        u = [5.0, 0.0]
+        @test massaction_rates!(zeros(1), single, u) == massaction_rates!(zeros(1), vector, u)
+        @test massaction_stoichiometry_mul!(zeros(2), single, [2.0]) ==
+            massaction_stoichiometry_mul!(zeros(2), vector, [2.0])
+        @test massaction_drift!(zeros(2), single, u) == massaction_drift!(zeros(2), vector, u)
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -24,6 +24,7 @@ end
         @time @safetestset "Split Coupled Tests" begin include("splitcoupled.jl") end
         @time @safetestset "SSA Tests" begin include("ssa_tests.jl") end
         @time @safetestset "Tau Leaping Tests" begin include("regular_jumps.jl") end
+        @time @safetestset "Mass-action leaping interface" begin include("massaction_leaping.jl") end
         @time @safetestset "Simple SSA Callback Test" begin include("ssa_callback_test.jl") end
         @time @safetestset "SIR Discrete Callback Test" begin include("sir_model.jl") end
         @time @safetestset "Callback Merging Tests" begin include("callbacks.jl") end
@@ -57,12 +58,21 @@ end
         @time @safetestset "Spatial A + B <--> C" begin include("spatial/ABC.jl") end
         @time @safetestset "Spatially Varying Reaction Rates" begin include("spatial/spatial_majump.jl") end
         @time @safetestset "Pure diffusion" begin include("spatial/diffusion.jl") end
+        @time @safetestset "Fixed-step mass-action kernel on CPU" begin
+            include("massaction_fixed_tau_kernel.jl")
+            test_massaction_fixed_tau_kernel(CPU())
+        end
         @time @safetestset "SSA kernel on the CPU backend" begin include("kernelabstractions_ssa.jl") end
         @time @safetestset "Explicit tau-leaping kernel on the CPU backend" begin include("kernelabstractions_explicit_tau.jl") end
     end
 
     if GROUP == "CUDA"
         activate_gpu_env()
+        @time @safetestset "GPU fixed-step mass-action kernel" begin
+            using CUDA
+            include("massaction_fixed_tau_kernel.jl")
+            test_massaction_fixed_tau_kernel(CUDABackend())
+        end
         @time @safetestset "GPU Tau Leaping test" begin include("gpu/regular_jumps.jl") end
         @time @safetestset "GPU SSA test" begin include("gpu/ssa.jl") end
         @time @safetestset "GPU Explicit Tau Leaping test" begin include("gpu/explicit_tau.jl") end


### PR DESCRIPTION
Preserve `MassActionJump` in `JumpProblem` and let tau-leaping solvers consume its stored rates and stoichiometry. `SimpleTauLeaping` now uses native mass-action data on CPU and the flattened mass-action representation in GPU kernels; general `RegularJump` input remains supported. This replaces the constructor-level conversion raised in review.

Add documented public propensity, stoichiometry-product, and fused drift operations for downstream solvers, with a minor version bump to 9.33. The companion StochasticDiffEq implementation uses these operations directly: https://github.com/SciML/OrdinaryDiffEq.jl/pull/4523 . This prerequisite can be released independently; its executable examples use JumpProcesses solvers. The full cross-package guide is https://github.com/SciML/JumpProcesses.jl/pull/650 .

## Verification

Julia 1.12.6 with dependencies developed in a local environment. Existing test entry points were used because `Pkg.test` encountered a relative-`[sources]` sandbox resolution error in the local monorepo dependency setup.

```sh
GROUP=InterfaceI julia --project=native-validation massaction-leaping/test/runtests.jl
GROUP=InterfaceII julia --project=native-validation massaction-leaping/test/runtests.jl
GROUP=QA julia --project=native-validation massaction-leaping/test/runtests.jl
julia --project=massaction-leaping/docs massaction-leaping/docs/make.jl
```

```text
InterfaceI: 940 passing checks across 21 testsets
InterfaceII: 1597 passing checks across 21 testsets
QA Tests | 20 20
[ Info: HTMLWriter: rendering HTML pages.
[ Info: Automatic `version="9.33.0"` for inventory from ../Project.toml
```

The new mass-action checks pass 29 assertions. KernelAbstractions CPU-backend checks include 12 fixed-step mass-action, 67 SSA, and 80 adaptive explicit assertions.

Runic on changed Julia lines, `typos` over changed files, and `git diff --check` passed. GPU kernels ran through KernelAbstractions' CPU backend; no physical GPU execution was performed. Adaptive implicit, trapezoidal, and switching methods have no GPU implementation.

The constructor regression test discriminates against the previous adapter implementation (https://github.com/SciML/JumpProcesses.jl/commit/663b28171df580638a7512a459c8e0ac51909305):

```text
Before: Test Failed: prob.regular_jump === nothing
After:  same assertion passes (exit 0)
```

The public operation tests cover scalar and vector reaction storage, zero populations, higher-order reactions, and derivative propagation. A scalar reaction test produced six errors before the scalar-data fix and passes all six checks afterward. Native/regular fixed-seed trajectory comparisons and unsupported mixed-jump rejection are included.

Ignore this PR until reviewed by @ChrisRackauckas.

🤖 Generated with Codex CLI 0.153.4 (model: gpt-6-astra; local session ID: 01a070e6-21f2-7dd3-bf52-2ddaf108ac53).
