### PR TITLE
Add optional rate bounds to ConstantRateJump

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -23,6 +23,7 @@ MassActionJump
 VariableRateJump
 RegularJump
 JumpSet
+RateBounds
 ```
 
 ## Aggregator Types

--- a/docs/src/jump_types.md
+++ b/docs/src/jump_types.md
@@ -75,7 +75,7 @@ their own special time integrators.
 The constructor for a [`ConstantRateJump`](@ref) is:
 
 ```julia
-ConstantRateJump(rate, affect!)
+ConstantRateJump(rate, affect!; bounds=nothing)
 ```
 
   - `rate(u, p, t)` is a function which calculates the rate given the current
@@ -84,10 +84,11 @@ ConstantRateJump(rate, affect!)
     interface. It encodes how the state should change due to *one* occurrence of
     the jump.
 
-For aggregators that bracket rates over state intervals, such as `RSSA` and `RSSACR`, one
-can also supply `lrate` and `urate` rate bound functions. If not supplied, these bounds
-will be computed automatically by evaluating `rate` at the interval endpoints (which is
-only correct for rate functions that are increasing, such as mass action rates).
+For aggregators that bracket rates, such as `RSSA` and `RSSACR`, one can also supply a
+`bounds(ulow, uhigh, p, t)` function returning a [`RateBounds`](@ref) that bounds `rate`
+over the state bracket `[ulow, uhigh]`. If not supplied, the bounds are computed
+automatically by evaluating `rate` at the endpoints of the bracket (which is only correct
+for rate functions that are monotonic in the state, such as mass action rates).
 
 #### Defining a Mass Action Jump
 

--- a/docs/src/jump_types.md
+++ b/docs/src/jump_types.md
@@ -85,7 +85,7 @@ ConstantRateJump(rate, affect!; bounds=nothing)
     the jump.
 
 For aggregators that bracket rates, such as `RSSA` and `RSSACR`, one can also supply a
-`bounds(ulow, uhigh, p, t)` function returning a [`RateBounds`](@ref) that bounds `rate`
+`bounds(ulow, uhigh, u, p, t)` function returning a [`RateBounds`](@ref) that bounds `rate`
 over the state bracket `[ulow, uhigh]`. If not supplied, the bounds are computed
 automatically by evaluating `rate` at the endpoints of the bracket (which is only correct
 for rate functions that are monotonic in the state, such as mass action rates).

--- a/docs/src/jump_types.md
+++ b/docs/src/jump_types.md
@@ -84,6 +84,11 @@ ConstantRateJump(rate, affect!)
     interface. It encodes how the state should change due to *one* occurrence of
     the jump.
 
+For aggregators that bracket rates over state intervals, such as `RSSA` and `RSSACR`, one
+can also supply `lrate` and `urate` rate bound functions. If not supplied, these bounds
+will be computed automatically by evaluating `rate` at the interval endpoints (which is
+only correct for rate functions that are increasing, such as mass action rates).
+
 #### Defining a Mass Action Jump
 
 The constructor for a [`MassActionJump`](@ref) is:
@@ -294,6 +299,8 @@ aggregator requires various types of dependency graphs, see the next section):
   - `RSSA`: The Rejection SSA (RSSA) method of Thanh *et al.* [^5][^6]. With `RSSACR`,
     for very large reaction networks, it often offers the best performance of all
     methods. [Dependency graph required](@ref Jump-Aggregators-Requiring-Dependency-Graphs).
+    For `ConstantRateJump`s, `RSSA` and `RSSACR` require rate bounds, see
+    [`ConstantRateJump`](@ref).
   - `RSSACR`: The Rejection SSA (RSSA) with Composition-Rejection method of
     Thanh *et al.* [^7]. With `RSSA`, for very large reaction networks, it often offers
     the best performance of all methods. [Dependency graph required](@ref Jump-Aggregators-Requiring-Dependency-Graphs).

--- a/src/JumpProcesses.jl
+++ b/src/JumpProcesses.jl
@@ -70,7 +70,7 @@ const USE_RSSA_THRESHOLD = 100
 const USE_SORTINGDIRECT_THRESHOLD = 200
 
 include("jumps.jl")
-export ConstantRateJump, VariableRateJump, RegularJump, MassActionJump, JumpSet
+export ConstantRateJump, VariableRateJump, RegularJump, MassActionJump, JumpSet, RateBounds
 
 include("massaction_rates.jl")
 

--- a/src/aggregators/bracketing.jl
+++ b/src/aggregators/bracketing.jl
@@ -86,13 +86,13 @@ end
 """
 get brackets for the rate of reaction rx by first checking if the reaction is a massaction reaction
 """
-@inline function get_jump_brackets(rx, p::AbstractSSAJumpAggregator, params, t)
+@inline function get_jump_brackets(rx, p::AbstractSSAJumpAggregator, u, params, t)
     ma_jumps = p.ma_jumps
     num_majumps = get_num_majumps(ma_jumps)
     if rx <= num_majumps
         return get_majump_brackets(p.ulow, p.uhigh, rx, ma_jumps)
     else
-        @inbounds return p.brackets[rx - num_majumps](p.ulow, p.uhigh, params, t)
+        @inbounds return p.brackets[rx - num_majumps](p.ulow, p.uhigh, u, params, t)
     end
 end
 
@@ -128,7 +128,7 @@ function set_bracketing!(p::AbstractSSAJumpAggregator, u, params, t)
     # reaction rate bracketing interval
     sum_rate = zero(p.sum_rate)
     @inbounds for rx in 1:(get_num_majumps(p.ma_jumps) + length(p.brackets))
-        p.cur_rate_low[rx], p.cur_rate_high[rx] = get_jump_brackets(rx, p, params, t)
+        p.cur_rate_low[rx], p.cur_rate_high[rx] = get_jump_brackets(rx, p, u, params, t)
         sum_rate += p.cur_rate_high[rx]
     end
     p.sum_rate = sum_rate

--- a/src/aggregators/bracketing.jl
+++ b/src/aggregators/bracketing.jl
@@ -83,14 +83,6 @@ end
     evalrxrate(ulow, k, majumps), evalrxrate(uhigh, k, majumps)
 end
 
-# for constant rate jumps we must check the ordering of the bracket values
-# Get propensity brackets of constant rate jump.
-@inline function get_cjump_brackets(ulow, uhigh, rate, params, t)
-    rlow = rate(ulow, params, t)
-    rhigh = rate(uhigh, params, t)
-    return (rlow <= rhigh) ? (rlow, rhigh) : (rhigh, rlow)
-end
-
 """
 get brackets for the rate of reaction rx by first checking if the reaction is a massaction reaction
 """
@@ -100,8 +92,7 @@ get brackets for the rate of reaction rx by first checking if the reaction is a 
     if rx <= num_majumps
         return get_majump_brackets(p.ulow, p.uhigh, rx, ma_jumps)
     else
-        @inbounds return get_cjump_brackets(p.ulow, p.uhigh, p.rates[rx - num_majumps],
-            params, t)
+        @inbounds return p.brackets[rx - num_majumps](p.ulow, p.uhigh, params, t)
     end
 end
 
@@ -129,28 +120,16 @@ end
 end
 
 # Set up bracketing. The aggregator must have fields
-#    ulow, uhigh, cur_rate_low, cur_rate_high, sum_rate, ma_jumps, rates.
+#    ulow, uhigh, cur_rate_low, cur_rate_high, sum_rate, ma_jumps, rates, brackets
 function set_bracketing!(p::AbstractSSAJumpAggregator, u, params, t)
     # species bracketing interval
     update_u_brackets!(p, u)
 
     # reaction rate bracketing interval
-    # mass action jumps
     sum_rate = zero(p.sum_rate)
-    majumps = p.ma_jumps
-    crlow = p.cur_rate_low
-    crhigh = p.cur_rate_high
-    @inbounds for k in 1:get_num_majumps(majumps)
-        crlow[k], crhigh[k] = get_majump_brackets(p.ulow, p.uhigh, k, majumps)
-        sum_rate += crhigh[k]
-    end
-
-    # constant rate jumps
-    k = get_num_majumps(majumps) + 1
-    @inbounds for rate in p.rates
-        crlow[k], crhigh[k] = get_cjump_brackets(p.ulow, p.uhigh, rate, params, t)
-        sum_rate += crhigh[k]
-        k += 1
+    @inbounds for rx in 1:(get_num_majumps(p.ma_jumps) + length(p.brackets))
+        p.cur_rate_low[rx], p.cur_rate_high[rx] = get_jump_brackets(rx, p, params, t)
+        sum_rate += p.cur_rate_high[rx]
     end
     p.sum_rate = sum_rate
 

--- a/src/aggregators/rssa.jl
+++ b/src/aggregators/rssa.jl
@@ -161,7 +161,7 @@ Update rates
             # for each dependent jump, update jump rate brackets
             for jidx in p.vartojumps_map[uidx]
                 sum_rate -= crhigh[jidx]
-                p.cur_rate_low[jidx], crhigh[jidx] = get_jump_brackets(jidx, p, params, t)
+                p.cur_rate_low[jidx], crhigh[jidx] = get_jump_brackets(jidx, p, u, params, t)
                 sum_rate += crhigh[jidx]
             end
         end
@@ -187,7 +187,7 @@ end
             # for each dependent jump, update jump rate brackets
             for jidx in p.vartojumps_map[uidx]
                 sum_rate -= crhigh[jidx]
-                p.cur_rate_low[jidx], crhigh[jidx] = get_jump_brackets(jidx, p, params, t)
+                p.cur_rate_low[jidx], crhigh[jidx] = get_jump_brackets(jidx, p, u, params, t)
                 sum_rate += crhigh[jidx]
             end
         end

--- a/src/aggregators/rssa.jl
+++ b/src/aggregators/rssa.jl
@@ -4,7 +4,7 @@
 # functions of the current population sizes (i.e. u)
 # requires vartojumps_map and fluct_rates as JumpProblem keywords
 
-mutable struct RSSAJumpAggregation{T, S, F1, F2, RNG, VJMAP, JVMAP, BD, U} <:
+mutable struct RSSAJumpAggregation{T, S, F1, F2, RNG, CB, VJMAP, JVMAP, BD, U} <:
                AbstractSSAJumpAggregator{T, S, F1, F2, RNG}
     next_jump::Int
     prev_jump::Int
@@ -16,6 +16,7 @@ mutable struct RSSAJumpAggregation{T, S, F1, F2, RNG, VJMAP, JVMAP, BD, U} <:
     ma_jumps::S
     rates::F1
     affects!::F2
+    brackets::CB
     save_positions::Tuple{Bool, Bool}
     rng::RNG
     vartojumps_map::VJMAP
@@ -27,7 +28,7 @@ end
 
 function RSSAJumpAggregation(nj::Int, njt::T, et::T, crs::Vector{T}, sr::T,
         maj::S, rs::F1, affs!::F2, sps::Tuple{Bool, Bool},
-        rng::RNG; u::U, vartojumps_map = nothing,
+        rng::RNG; u::U, brackets, vartojumps_map = nothing,
         jumptovars_map = nothing,
         bracket_data = nothing, kwargs...) where {T, S, F1, F2, RNG, U}
     # a dependency graph is needed and must be provided if there are constant rate jumps
@@ -63,9 +64,9 @@ function RSSAJumpAggregation(nj::Int, njt::T, et::T, crs::Vector{T}, sr::T,
     uhigh = similar(u)
 
     affecttype = F2 <: Tuple ? F2 : Any
-    RSSAJumpAggregation{T, S, F1, affecttype, RNG, typeof(vtoj_map),
+    RSSAJumpAggregation{T, S, F1, affecttype, RNG, typeof(brackets), typeof(vtoj_map),
         typeof(jtov_map), typeof(bd), U}(nj, nj, njt, et, crl_bnds,
-        crh_bnds, sr, maj, rs, affs!, sps,
+        crh_bnds, sr, maj, rs, affs!, brackets, sps,
         rng, vtoj_map, jtov_map, bd, ulow,
         uhigh)
 end
@@ -78,9 +79,10 @@ function aggregate(aggregator::RSSA, u, p, t, end_time, constant_jumps,
 
     # handle constant jumps using function wrappers
     rates, affects! = get_jump_info_fwrappers(u, p, t, constant_jumps)
+    brackets = get_jump_bracket_fwrappers(u, p, t, constant_jumps)
 
     build_jump_aggregation(RSSAJumpAggregation, u, p, t, end_time, ma_jumps,
-        rates, affects!, save_positions, rng; u = u,
+        rates, affects!, save_positions, rng; u = u, brackets,
         kwargs...)
 end
 

--- a/src/aggregators/rssa.jl
+++ b/src/aggregators/rssa.jl
@@ -79,7 +79,7 @@ function aggregate(aggregator::RSSA, u, p, t, end_time, constant_jumps,
 
     # handle constant jumps using function wrappers
     rates, affects! = get_jump_info_fwrappers(u, p, t, constant_jumps)
-    brackets = get_jump_bracket_fwrappers(u, p, t, constant_jumps)
+    brackets = get_jump_bracket_fwrappers(u, p, t, constant_jumps, aggregator)
 
     build_jump_aggregation(RSSAJumpAggregation, u, p, t, end_time, ma_jumps,
         rates, affects!, save_positions, rng; u = u, brackets,

--- a/src/aggregators/rssacr.jl
+++ b/src/aggregators/rssacr.jl
@@ -179,7 +179,7 @@ update bracketing for species that depend on the just executed jump
             # for each dependent jump, update jump rate brackets
             for jidx in p.vartojumps_map[uidx]
                 oldrate = crhigh[jidx]
-                p.cur_rate_low[jidx], crhigh[jidx] = get_jump_brackets(jidx, p, params, t)
+                p.cur_rate_low[jidx], crhigh[jidx] = get_jump_brackets(jidx, p, u, params, t)
 
                 # update the priority table
                 update!(p.rt, jidx, oldrate, crhigh[jidx])
@@ -207,7 +207,7 @@ end
             # for each dependent jump, update jump rate brackets
             for jidx in p.vartojumps_map[uidx]
                 oldrate = crhigh[jidx]
-                p.cur_rate_low[jidx], crhigh[jidx] = get_jump_brackets(jidx, p, params, t)
+                p.cur_rate_low[jidx], crhigh[jidx] = get_jump_brackets(jidx, p, u, params, t)
 
                 # update the priority table
                 update!(p.rt, jidx, oldrate, crhigh[jidx])

--- a/src/aggregators/rssacr.jl
+++ b/src/aggregators/rssacr.jl
@@ -4,7 +4,7 @@ Composition-Rejection with Rejection sampling method (RSSA-CR)
 
 const MINJUMPRATE = 2.0^exponent(1e-12)
 
-mutable struct RSSACRJumpAggregation{F, S, F1, F2, RNG, U, VJMAP, JVMAP, BD,
+mutable struct RSSACRJumpAggregation{F, S, F1, F2, RNG, CB, U, VJMAP, JVMAP, BD,
     P <: PriorityTable, W <: Function} <:
                AbstractSSAJumpAggregator{F, S, F1, F2, RNG}
     next_jump::Int
@@ -17,6 +17,7 @@ mutable struct RSSACRJumpAggregation{F, S, F1, F2, RNG, U, VJMAP, JVMAP, BD,
     ma_jumps::S
     rates::F1
     affects!::F2
+    brackets::CB
     save_positions::Tuple{Bool, Bool}
     rng::RNG
     vartojumps_map::VJMAP
@@ -31,7 +32,7 @@ mutable struct RSSACRJumpAggregation{F, S, F1, F2, RNG, U, VJMAP, JVMAP, BD,
 end
 
 function RSSACRJumpAggregation(nj::Int, njt::F, et::F, crs::Vector{F}, sum_rate::F, maj::S,
-        rs::F1, affs!::F2, sps::Tuple{Bool, Bool}, rng::RNG; u::U,
+        rs::F1, affs!::F2, sps::Tuple{Bool, Bool}, rng::RNG; u::U, brackets,
         vartojumps_map = nothing, jumptovars_map = nothing,
         bracket_data = nothing, minrate = convert(F, MINJUMPRATE),
         maxrate = convert(F, Inf),
@@ -80,10 +81,10 @@ function RSSACRJumpAggregation(nj::Int, njt::F, et::F, crs::Vector{F}, sum_rate:
     rt = PriorityTable(ratetogroup, zeros(F, 1), minrate, 2 * minrate)
 
     affecttype = F2 <: Tuple ? F2 : Any
-    RSSACRJumpAggregation{typeof(njt), S, F1, affecttype, RNG, U, typeof(vtoj_map),
-        typeof(jtov_map), typeof(bd), typeof(rt),
+    RSSACRJumpAggregation{typeof(njt), S, F1, affecttype, RNG, typeof(brackets), U,
+        typeof(vtoj_map), typeof(jtov_map), typeof(bd), typeof(rt),
         typeof(ratetogroup)}(nj, nj, njt, et, crl_bnds, crh_bnds,
-        sum_rate, maj, rs, affs!, sps, rng, vtoj_map,
+        sum_rate, maj, rs, affs!, brackets, sps, rng, vtoj_map,
         jtov_map, bd, ulow, uhigh, minrate, maxrate,
         rt, ratetogroup)
 end
@@ -96,9 +97,10 @@ function aggregate(aggregator::RSSACR, u, p, t, end_time, constant_jumps,
 
     # handle constant jumps using function wrappers
     rates, affects! = get_jump_info_fwrappers(u, p, t, constant_jumps)
+    brackets = get_jump_bracket_fwrappers(u, p, t, constant_jumps)
 
     build_jump_aggregation(RSSACRJumpAggregation, u, p, t, end_time, ma_jumps,
-        rates, affects!, save_positions, rng; u = u, kwargs...)
+        rates, affects!, save_positions, rng; u = u, brackets, kwargs...)
 end
 
 # set up a new simulation and calculate the first jump / jump time

--- a/src/aggregators/rssacr.jl
+++ b/src/aggregators/rssacr.jl
@@ -97,7 +97,7 @@ function aggregate(aggregator::RSSACR, u, p, t, end_time, constant_jumps,
 
     # handle constant jumps using function wrappers
     rates, affects! = get_jump_info_fwrappers(u, p, t, constant_jumps)
-    brackets = get_jump_bracket_fwrappers(u, p, t, constant_jumps)
+    brackets = get_jump_bracket_fwrappers(u, p, t, constant_jumps, aggregator)
 
     build_jump_aggregation(RSSACRJumpAggregation, u, p, t, end_time, ma_jumps,
         rates, affects!, save_positions, rng; u = u, brackets, kwargs...)

--- a/src/jumps.jl
+++ b/src/jumps.jl
@@ -1,3 +1,83 @@
+
+"""
+    RateBounds(; lrate, urate, rateinterval = Inf)
+
+Computed bounds on a jump's rate for a fixed state bracket `[ulow, uhigh]` at time `t`.
+
+## Fields
+
+$(FIELDS)
+
+## Notes
+
+  - The rates must satisfy `lrate <= rate(u, p, s) <= urate` for every `u` with `ulow .<= u .<= uhigh` and `s` in `[t, t + rateinterval]`.
+  - At least one of `lrate` or `urate` must be given. An omitted bound defaults to the trivially valid one: `zero` below and `typemax` above.
+  - For `ConstantRateJump`s, `rateinterval` is always `Inf`, as rates do not explicitly depend on `t`.
+
+## Examples
+
+```julia
+rate(u, p, t) = p[1] * u[1] / (1 + u[2])
+bounds(ulow, uhigh, p, t) = RateBounds(lrate = p[1] * ulow[1] / (1 + uhigh[2]),
+                                       urate = p[1] * uhigh[1] / (1 + ulow[2]))
+```
+"""
+struct RateBounds{R, T}
+    """Lower bound of the rate."""
+    lrate::R
+    """Upper bound of the rate."""
+    urate::R
+    """Time window over which the bounds hold."""
+    rateinterval::T
+end
+
+function RateBounds(; lrate=nothing, urate=nothing, rateinterval = Inf)
+    (lrate === nothing && urate === nothing) &&
+        error("`RateBounds` requires at least one of `lrate` or `urate`.")
+    l = lrate === nothing ? zero(urate) : lrate
+    u = urate === nothing ? typemax(lrate) : urate
+    RateBounds(promote(l, u)..., rateinterval)
+end
+
+"""
+    RateBoundFunctions(; bounds, lrate, urate)
+
+Rate bound functions stored on a jump.
+
+Each function takes `(ulow, uhigh, p, t)` and returns a [`RateBounds`](@ref) over the state bracket `[ulow, uhigh]`. Most aggregators call `bounds`. `lrate` and `urate` are exposed only for aggregators that benefit from the separation.
+
+## Fields
+
+$(FIELDS)
+
+## Notes
+
+  - All fields are optional, but an aggregator errors at initialization if the form it consumes is missing.
+"""
+struct RateBoundFunctions{B, L, U}
+    """Computes both bounds in a single call."""
+    bounds::B
+    """Computes the lower bound."""
+    lrate::L
+    """Computes the upper bound."""
+    urate::U
+end
+
+RateBoundFunctions(; bounds = nothing, lrate = nothing, urate = nothing) =
+    RateBoundFunctions(bounds, lrate, urate)
+
+hasbounds(::Nothing) = false
+hasbounds(::RateBoundFunctions{Nothing}) = false
+hasbounds(::RateBoundFunctions) = true
+
+haslrate(::Nothing) = false
+haslrate(::RateBoundFunctions{B, Nothing}) where {B} = false
+haslrate(::RateBoundFunctions) = true
+
+hasurate(::Nothing) = false
+hasurate(::RateBoundFunctions{B, L, Nothing}) where {B, L} = false
+hasurate(::RateBoundFunctions) = true
+
 """
 $(TYPEDEF)
 
@@ -23,69 +103,86 @@ crj = ConstantRateJump(rate, affect!)
 Notice, here that `rate` changes in time, but is constant between the occurrence
 of jumps (when `u[1]` will decrease).
 
-Rate bounds may be supplied separately for rate functions that are not monotonic, for use
-with bracketing aggregators such as `RSSA`:
+Rate bounds may be supplied separately, for use with bracketing aggregators such as `RSSA`:
 ```julia
-rate(u,p,t) = p[1]*u[1] / (1+u[2])
+rate(u, p, t) = p[1] * u[1] / (1 + u[2])
 affect!(integrator) = integrator.u[1] -= 1
-lrate(ulow, uhigh, p, t) = p[1]*ulow[1] / (1+uhigh[2])
-urate(ulow, uhigh, p, t) = p[1]*uhigh[1] / (1+ulow[2])
-crj = ConstantRateJump(rate, affect!; lrate = lrate, urate = urate)
+bounds(ulow, uhigh, p, t) = RateBounds(lrate=p[1]*ulow[1] / (1+uhigh[2]),
+                                       urate=p[1]*uhigh[1] / (1+ulow[2]))
+crj = ConstantRateJump(rate, affect!; bounds)
 ```
 
 ## Notes
 
-- Optional bounds `lrate(ulow, uhigh, p, t)` and `urate(ulow, uhigh, p, t)` may be
-  supplied for use with aggregators that bracket rates over state intervals, currently
-  `RSSA` and `RSSACR`. They must satisfy
-  `lrate(ulow, uhigh, p, t) <= rate(u, p, t) <= urate(ulow, uhigh, p, t)` for every `u`
-  with `ulow .<= u .<= uhigh`.
 - When rate bounds are not supplied, they are computed by evaluating the rate at `ulow`
   and `uhigh`. These bounds are only correct if the rate is monotonic with respect to
   state, i.e. increasing in all species or decreasing in all species.
 """
-struct ConstantRateJump{F1, F2, R1, R2} <: AbstractJump
+struct ConstantRateJump{F1, F2, B} <: AbstractJump
     """Function `rate(u,p,t)` that returns the jump's current rate."""
     rate::F1
     """Function `affect(integrator)` that updates the state for one occurrence of the jump."""
     affect!::F2
-    """Optional function `lrate(ulow, uhigh, p, t)` that computes a lower bound on the rate
-    over the state interval `[ulow, uhigh]` at time `t` with parameters `p`. `nothing` if
-    not supplied, in which case the `rate` is evaluated at the interval endpoints."""
-    lrate::R1
-    """Optional function `urate(ulow, uhigh, p, t)` that computes an upper bound on the rate
-    over the state interval `[ulow, uhigh]` at time `t` with parameters `p`. `nothing` if
-    not supplied, in which case the `rate` is evaluated at the interval endpoints."""
-    urate::R2
+    """Optional `RateBoundFunctions` holding user supplied bracketing functions."""
+    bounds::B
 end
 
-function ConstantRateJump(rate, affect!; lrate = nothing, urate = nothing)
-    ConstantRateJump(rate, affect!, lrate, urate)
+function ConstantRateJump(rate, affect!; bounds = nothing, lrate = nothing, urate = nothing)
+    if bounds === nothing && lrate === nothing && urate === nothing
+        ConstantRateJump(rate, affect!, nothing)
+    else
+        ConstantRateJump(rate, affect!, RateBoundFunctions(bounds, lrate, urate))
+    end
 end
 
-@inline lower_rate_bound(c::ConstantRateJump, ulow, uhigh, p, t) =
-    c.lrate(ulow, uhigh, p, t)
+hasbounds(c::ConstantRateJump) = hasbounds(c.bounds)
+haslrate(c::ConstantRateJump) = haslrate(c.bounds)
+hasurate(c::ConstantRateJump) = hasurate(c.bounds)
 
+check_jump_bounds(::ConstantRateJump{F1, F2, Nothing}, i, agg) where {F1, F2} = nothing
+function check_jump_bounds(c::ConstantRateJump, i, agg)
+    hasbounds(c) ||
+        error("$(nameof(typeof(agg))) requires a joint rate bound. Pass `bounds` when constructing `ConstantRateJump` $i.")
+    nothing
+end
+
+check_jump_lrate(::ConstantRateJump{F1, F2, Nothing}, i, agg) where {F1, F2} = nothing
+function check_jump_lrate(c::ConstantRateJump, i, agg)
+    haslrate(c) ||
+        error("$(nameof(typeof(agg))) requires a lower rate bound. Pass `lrate` when constructing `ConstantRateJump` $i.")
+    nothing
+end
+
+check_jump_urate(::ConstantRateJump{F1, F2, Nothing}, i, agg) where {F1, F2} = nothing
+function check_jump_urate(c::ConstantRateJump, i, agg)
+    hasurate(c) ||
+        error("$(nameof(typeof(agg))) requires an upper rate bound. Pass `urate` when constructing `ConstantRateJump` $i.")
+    nothing
+end
+
+@inline function cjump_brackets(c::ConstantRateJump, ulow, uhigh, p, t)
+    b = c.bounds.bounds(ulow, uhigh, p, t)
+    (b.lrate, b.urate)
+end
 # fallback assumes the rate is monotonic in the state; it would be cleaner to demand
 # user-specified bounds for decreasing rates and only handle the increasing case by default
-@inline lower_rate_bound(c::ConstantRateJump{F1, F2, Nothing}, ulow, uhigh, p,
-        t) where {F1, F2} = min(c.rate(ulow, p, t), c.rate(uhigh, p, t))
-
-@inline upper_rate_bound(c::ConstantRateJump, ulow, uhigh, p, t) =
-    c.urate(ulow, uhigh, p, t)
-
-@inline upper_rate_bound(c::ConstantRateJump{F1, F2, R1, Nothing}, ulow, uhigh, p,
-        t) where {F1, F2, R1} = max(c.rate(ulow, p, t), c.rate(uhigh, p, t))
-
-@inline function cjump_brackets(c::ConstantRateJump{F1, F2, Nothing, Nothing}, ulow,
-        uhigh, p, t) where {F1, F2}
+@inline function cjump_brackets(c::ConstantRateJump{F1, F2, Nothing},
+    ulow, uhigh, p, t) where {F1, F2}
     rlow = c.rate(ulow, p, t)
     rhigh = c.rate(uhigh, p, t)
     rlow <= rhigh ? (rlow, rhigh) : (rhigh, rlow)
 end
 
-@inline cjump_brackets(c::ConstantRateJump, ulow, uhigh, p, t) =
-    (lower_rate_bound(c, ulow, uhigh, p, t), upper_rate_bound(c, ulow, uhigh, p, t))
+@inline lower_rate_bound(c::ConstantRateJump, ulow, uhigh, p, t) =
+    c.bounds.lrate(ulow, uhigh, p, t).lrate
+@inline lower_rate_bound(c::ConstantRateJump{F1, F2, Nothing}, ulow, uhigh, p,
+        t) where {F1, F2} = min(c.rate(ulow, p, t), c.rate(uhigh, p, t))
+
+@inline upper_rate_bound(c::ConstantRateJump, ulow, uhigh, p, t) =
+    c.bounds.urate(ulow, uhigh, p, t).urate
+@inline upper_rate_bound(c::ConstantRateJump{F1, F2, Nothing}, ulow, uhigh, p,
+        t) where {F1, F2} = max(c.rate(ulow, p, t), c.rate(uhigh, p, t))
+
 
 """
 $(TYPEDEF)
@@ -843,11 +940,14 @@ function get_jump_info_fwrappers(u, p, t, jumps)
     rates, affects!
 end
 
-function get_jump_bracket_fwrappers(u, p, t, jumps)
+function get_jump_bracket_fwrappers(u, p, t, jumps, agg)
     BracketWrapper = FunctionWrappers.FunctionWrapper{Tuple{typeof(t), typeof(t)},
         Tuple{typeof(u), typeof(u), typeof(p), typeof(t)}}
 
     if (jumps !== nothing) && !isempty(jumps)
+        for (i, c) in enumerate(jumps)
+            check_jump_bounds(c, i, agg)
+        end
         [BracketWrapper(make_bracket_fn(c)) for c in jumps]
     else
         Vector{BracketWrapper}()
@@ -856,3 +956,37 @@ end
 
 make_bracket_fn(c::ConstantRateJump) =
     (ulow, uhigh, p, t) -> cjump_brackets(c, ulow, uhigh, p, t)
+
+function get_jump_lrate_fwrappers(u, p, t, jumps, agg)
+    BoundWrapper = FunctionWrappers.FunctionWrapper{typeof(t),
+        Tuple{typeof(u), typeof(u), typeof(p), typeof(t)}}
+
+    if (jumps !== nothing) && !isempty(jumps)
+        for (i, c) in enumerate(jumps)
+            check_jump_lrate(c, i, agg)
+        end
+        [BoundWrapper(make_lrate_fn(c)) for c in jumps]
+    else
+        Vector{BoundWrapper}()
+    end
+end
+
+function get_jump_urate_fwrappers(u, p, t, jumps, agg)
+    BoundWrapper = FunctionWrappers.FunctionWrapper{typeof(t),
+        Tuple{typeof(u), typeof(u), typeof(p), typeof(t)}}
+
+    if (jumps !== nothing) && !isempty(jumps)
+        for (i, c) in enumerate(jumps)
+            check_jump_urate(c, i, agg)
+        end
+        [BoundWrapper(make_urate_fn(c)) for c in jumps]
+    else
+        Vector{BoundWrapper}()
+    end
+end
+
+make_lrate_fn(c::ConstantRateJump) =
+    (ulow, uhigh, p, t) -> lower_rate_bound(c, ulow, uhigh, p, t)
+
+make_urate_fn(c::ConstantRateJump) =
+    (ulow, uhigh, p, t) -> upper_rate_bound(c, ulow, uhigh, p, t)

--- a/src/jumps.jl
+++ b/src/jumps.jl
@@ -22,13 +22,70 @@ crj = ConstantRateJump(rate, affect!)
 ```
 Notice, here that `rate` changes in time, but is constant between the occurrence
 of jumps (when `u[1]` will decrease).
+
+Rate bounds may be supplied separately for rate functions that are not monotonic, for use
+with bracketing aggregators such as `RSSA`:
+```julia
+rate(u,p,t) = p[1]*u[1] / (1+u[2])
+affect!(integrator) = integrator.u[1] -= 1
+lrate(ulow, uhigh, p, t) = p[1]*ulow[1] / (1+uhigh[2])
+urate(ulow, uhigh, p, t) = p[1]*uhigh[1] / (1+ulow[2])
+crj = ConstantRateJump(rate, affect!; lrate = lrate, urate = urate)
+```
+
+## Notes
+
+- Optional bounds `lrate(ulow, uhigh, p, t)` and `urate(ulow, uhigh, p, t)` may be
+  supplied for use with aggregators that bracket rates over state intervals, currently
+  `RSSA` and `RSSACR`. They must satisfy
+  `lrate(ulow, uhigh, p, t) <= rate(u, p, t) <= urate(ulow, uhigh, p, t)` for every `u`
+  with `ulow .<= u .<= uhigh`.
+- When rate bounds are not supplied, they are computed by evaluating the rate at `ulow`
+  and `uhigh`. These bounds are only correct if the rate is monotonic with respect to
+  state, i.e. increasing in all species or decreasing in all species.
 """
-struct ConstantRateJump{F1, F2} <: AbstractJump
+struct ConstantRateJump{F1, F2, R1, R2} <: AbstractJump
     """Function `rate(u,p,t)` that returns the jump's current rate."""
     rate::F1
     """Function `affect(integrator)` that updates the state for one occurrence of the jump."""
     affect!::F2
+    """Optional function `lrate(ulow, uhigh, p, t)` that computes a lower bound on the rate
+    over the state interval `[ulow, uhigh]` at time `t` with parameters `p`. `nothing` if
+    not supplied, in which case the `rate` is evaluated at the interval endpoints."""
+    lrate::R1
+    """Optional function `urate(ulow, uhigh, p, t)` that computes an upper bound on the rate
+    over the state interval `[ulow, uhigh]` at time `t` with parameters `p`. `nothing` if
+    not supplied, in which case the `rate` is evaluated at the interval endpoints."""
+    urate::R2
 end
+
+function ConstantRateJump(rate, affect!; lrate = nothing, urate = nothing)
+    ConstantRateJump(rate, affect!, lrate, urate)
+end
+
+@inline lower_rate_bound(c::ConstantRateJump, ulow, uhigh, p, t) =
+    c.lrate(ulow, uhigh, p, t)
+
+# fallback assumes the rate is monotonic in the state; it would be cleaner to demand
+# user-specified bounds for decreasing rates and only handle the increasing case by default
+@inline lower_rate_bound(c::ConstantRateJump{F1, F2, Nothing}, ulow, uhigh, p,
+        t) where {F1, F2} = min(c.rate(ulow, p, t), c.rate(uhigh, p, t))
+
+@inline upper_rate_bound(c::ConstantRateJump, ulow, uhigh, p, t) =
+    c.urate(ulow, uhigh, p, t)
+
+@inline upper_rate_bound(c::ConstantRateJump{F1, F2, R1, Nothing}, ulow, uhigh, p,
+        t) where {F1, F2, R1} = max(c.rate(ulow, p, t), c.rate(uhigh, p, t))
+
+@inline function cjump_brackets(c::ConstantRateJump{F1, F2, Nothing, Nothing}, ulow,
+        uhigh, p, t) where {F1, F2}
+    rlow = c.rate(ulow, p, t)
+    rhigh = c.rate(uhigh, p, t)
+    rlow <= rhigh ? (rlow, rhigh) : (rhigh, rlow)
+end
+
+@inline cjump_brackets(c::ConstantRateJump, ulow, uhigh, p, t) =
+    (lower_rate_bound(c, ulow, uhigh, p, t), upper_rate_bound(c, ulow, uhigh, p, t))
 
 """
 $(TYPEDEF)
@@ -785,3 +842,17 @@ function get_jump_info_fwrappers(u, p, t, jumps)
 
     rates, affects!
 end
+
+function get_jump_bracket_fwrappers(u, p, t, jumps)
+    BracketWrapper = FunctionWrappers.FunctionWrapper{Tuple{typeof(t), typeof(t)},
+        Tuple{typeof(u), typeof(u), typeof(p), typeof(t)}}
+
+    if (jumps !== nothing) && !isempty(jumps)
+        [BracketWrapper(make_bracket_fn(c)) for c in jumps]
+    else
+        Vector{BracketWrapper}()
+    end
+end
+
+make_bracket_fn(c::ConstantRateJump) =
+    (ulow, uhigh, p, t) -> cjump_brackets(c, ulow, uhigh, p, t)

--- a/src/jumps.jl
+++ b/src/jumps.jl
@@ -10,16 +10,39 @@ $(FIELDS)
 
 ## Notes
 
-  - The rates must satisfy `lrate <= rate(u, p, s) <= urate` for every `u` with `ulow .<= u .<= uhigh` and `s` in `[t, t + rateinterval]`.
+  - The rates must satisfy `lrate <= rate(v, p, s) <= urate` for every `v` with `ulow .<= v .<= uhigh` and `s` in `[t, t + rateinterval]`.
   - At least one of `lrate` or `urate` must be given. An omitted bound defaults to the trivially valid one: `zero` below and `typemax` above.
   - For `ConstantRateJump`s, `rateinterval` is always `Inf`, as rates do not explicitly depend on `t`.
 
 ## Examples
 
+Increasing rate in one species but decreasing in another:
 ```julia
 rate(u, p, t) = p[1] * u[1] / (1 + u[2])
-bounds(ulow, uhigh, p, t) = RateBounds(lrate = p[1] * ulow[1] / (1 + uhigh[2]),
-                                       urate = p[1] * uhigh[1] / (1 + ulow[2]))
+bounds(ulow, uhigh, u, p, t) = RateBounds(lrate = p[1] * ulow[1] / (1 + uhigh[2]),
+                                          urate = p[1] * uhigh[1] / (1 + ulow[2]))
+```
+
+Extremas lying inside the bracket:
+```julia
+rate(u, p, t) = p[1] * u[1] * (p[2] - u[1])
+function bounds(ulow, uhigh, u, p, t)
+    L = p[1] * max(abs(p[2] - 2*ulow[1]), abs(p[2] - 2*uhigh[1]))
+    δr = L * max(u[1] - ulow[1], uhigh[1] - u[1])
+    r = rate(u, p, t)
+    RateBounds(lrate = max(r - δr, zero(r)), urate = r + δr)
+end
+```
+
+Rate that depends on time:
+```julia
+rate(u, p, t) = p[1] * u[1] * exp(-p[2] * t)
+function bounds(ulow, uhigh, u, p, t)
+    Δ = p[3]
+    RateBounds(lrate = p[1] * ulow[1] * exp(-p[2] * (t + Δ)),
+               urate = p[1] * uhigh[1] * exp(-p[2] * t),
+               rateinterval = Δ)
+end
 ```
 """
 struct RateBounds{R, T}
@@ -44,7 +67,7 @@ end
 
 Rate bound functions stored on a jump.
 
-Each function takes `(ulow, uhigh, p, t)` and returns a [`RateBounds`](@ref) over the state bracket `[ulow, uhigh]`. Most aggregators call `bounds`. `lrate` and `urate` are exposed only for aggregators that benefit from the separation.
+Each function takes `(ulow, uhigh, u, p, t)` and returns a [`RateBounds`](@ref) over the state bracket `[ulow, uhigh]`. Most aggregators call `bounds`. `lrate` and `urate` are exposed only for aggregators that benefit from the separation.
 
 ## Fields
 
@@ -107,8 +130,8 @@ Rate bounds may be supplied separately, for use with bracketing aggregators such
 ```julia
 rate(u, p, t) = p[1] * u[1] / (1 + u[2])
 affect!(integrator) = integrator.u[1] -= 1
-bounds(ulow, uhigh, p, t) = RateBounds(lrate=p[1]*ulow[1] / (1+uhigh[2]),
-                                       urate=p[1]*uhigh[1] / (1+ulow[2]))
+bounds(ulow, uhigh, u, p, t) = RateBounds(lrate=p[1]*ulow[1] / (1+uhigh[2]),
+                                          urate=p[1]*uhigh[1] / (1+ulow[2]))
 crj = ConstantRateJump(rate, affect!; bounds)
 ```
 
@@ -160,27 +183,27 @@ function check_jump_urate(c::ConstantRateJump, i, agg)
     nothing
 end
 
-@inline function cjump_brackets(c::ConstantRateJump, ulow, uhigh, p, t)
-    b = c.bounds.bounds(ulow, uhigh, p, t)
+@inline function cjump_brackets(c::ConstantRateJump, ulow, uhigh, u, p, t)
+    b = c.bounds.bounds(ulow, uhigh, u, p, t)
     (b.lrate, b.urate)
 end
 # fallback assumes the rate is monotonic in the state; it would be cleaner to demand
 # user-specified bounds for decreasing rates and only handle the increasing case by default
 @inline function cjump_brackets(c::ConstantRateJump{F1, F2, Nothing},
-    ulow, uhigh, p, t) where {F1, F2}
+    ulow, uhigh, u, p, t) where {F1, F2}
     rlow = c.rate(ulow, p, t)
     rhigh = c.rate(uhigh, p, t)
     rlow <= rhigh ? (rlow, rhigh) : (rhigh, rlow)
 end
 
-@inline lower_rate_bound(c::ConstantRateJump, ulow, uhigh, p, t) =
-    c.bounds.lrate(ulow, uhigh, p, t).lrate
-@inline lower_rate_bound(c::ConstantRateJump{F1, F2, Nothing}, ulow, uhigh, p,
+@inline lower_rate_bound(c::ConstantRateJump, ulow, uhigh, u, p, t) =
+    c.bounds.lrate(ulow, uhigh, u, p, t).lrate
+@inline lower_rate_bound(c::ConstantRateJump{F1, F2, Nothing}, ulow, uhigh, u, p,
         t) where {F1, F2} = min(c.rate(ulow, p, t), c.rate(uhigh, p, t))
 
-@inline upper_rate_bound(c::ConstantRateJump, ulow, uhigh, p, t) =
-    c.bounds.urate(ulow, uhigh, p, t).urate
-@inline upper_rate_bound(c::ConstantRateJump{F1, F2, Nothing}, ulow, uhigh, p,
+@inline upper_rate_bound(c::ConstantRateJump, ulow, uhigh, u, p, t) =
+    c.bounds.urate(ulow, uhigh, u, p, t).urate
+@inline upper_rate_bound(c::ConstantRateJump{F1, F2, Nothing}, ulow, uhigh, u, p,
         t) where {F1, F2} = max(c.rate(ulow, p, t), c.rate(uhigh, p, t))
 
 
@@ -368,7 +391,7 @@ function rate!(out, u, p, t)
 end
 
 const dc = zeros(3,2)
-function c(du, u, p, t, counts, mark) 
+function c(du, u, p, t, counts, mark)
     mul!(du, dc, counts)
     nothing
 end
@@ -942,7 +965,7 @@ end
 
 function get_jump_bracket_fwrappers(u, p, t, jumps, agg)
     BracketWrapper = FunctionWrappers.FunctionWrapper{Tuple{typeof(t), typeof(t)},
-        Tuple{typeof(u), typeof(u), typeof(p), typeof(t)}}
+        Tuple{typeof(u), typeof(u), typeof(u), typeof(p), typeof(t)}}
 
     if (jumps !== nothing) && !isempty(jumps)
         for (i, c) in enumerate(jumps)
@@ -955,11 +978,11 @@ function get_jump_bracket_fwrappers(u, p, t, jumps, agg)
 end
 
 make_bracket_fn(c::ConstantRateJump) =
-    (ulow, uhigh, p, t) -> cjump_brackets(c, ulow, uhigh, p, t)
+    (ulow, uhigh, u, p, t) -> cjump_brackets(c, ulow, uhigh, u, p, t)
 
 function get_jump_lrate_fwrappers(u, p, t, jumps, agg)
     BoundWrapper = FunctionWrappers.FunctionWrapper{typeof(t),
-        Tuple{typeof(u), typeof(u), typeof(p), typeof(t)}}
+        Tuple{typeof(u), typeof(u), typeof(u), typeof(p), typeof(t)}}
 
     if (jumps !== nothing) && !isempty(jumps)
         for (i, c) in enumerate(jumps)
@@ -973,7 +996,7 @@ end
 
 function get_jump_urate_fwrappers(u, p, t, jumps, agg)
     BoundWrapper = FunctionWrappers.FunctionWrapper{typeof(t),
-        Tuple{typeof(u), typeof(u), typeof(p), typeof(t)}}
+        Tuple{typeof(u), typeof(u), typeof(u), typeof(p), typeof(t)}}
 
     if (jumps !== nothing) && !isempty(jumps)
         for (i, c) in enumerate(jumps)
@@ -986,7 +1009,7 @@ function get_jump_urate_fwrappers(u, p, t, jumps, agg)
 end
 
 make_lrate_fn(c::ConstantRateJump) =
-    (ulow, uhigh, p, t) -> lower_rate_bound(c, ulow, uhigh, p, t)
+    (ulow, uhigh, u, p, t) -> lower_rate_bound(c, ulow, uhigh, u, p, t)
 
 make_urate_fn(c::ConstantRateJump) =
-    (ulow, uhigh, p, t) -> upper_rate_bound(c, ulow, uhigh, p, t)
+    (ulow, uhigh, u, p, t) -> upper_rate_bound(c, ulow, uhigh, u, p, t)

--- a/test/bracketing.jl
+++ b/test/bracketing.jl
@@ -42,13 +42,15 @@ reaction_index = 1
 
 # constant rate
 rate(u, params, t) = 1 / u[1]
+affect!(integrator) = nothing
+crj = ConstantRateJump(rate, affect!)
 params = nothing
 t = 0.0
-@test JP.get_cjump_brackets(ulow, uhigh, rate, params, t)[1] == 1 / 10 # low
-@test JP.get_cjump_brackets(ulow, uhigh, rate, params, t)[2] == 1 / 2 # high
+@test JP.cjump_brackets(crj, ulow, uhigh, params, t)[1] == 1 / 10 # low
+@test JP.cjump_brackets(crj, ulow, uhigh, params, t)[2] == 1 / 2 # high
 
 ### Aggregator ###
-mutable struct DummyAggregator{T, M, R, BD} <:
+mutable struct DummyAggregator{T, M, R, CB, BD} <:
                JP.AbstractSSAJumpAggregator{T, M, R, Nothing, Nothing}
     ulow::Vector{Int}
     uhigh::Vector{Int}
@@ -57,13 +59,16 @@ mutable struct DummyAggregator{T, M, R, BD} <:
     sum_rate::T
     ma_jumps::M
     rates::R
+    brackets::CB
     bracket_data::BD
 end
 # one massaction jump, one constant rate jump
 cur_rate_low = [0.0, 0.0]
 cur_rate_high = [0.0, 0.0]
 sum_rate = 0.0
-p = DummyAggregator([0], [0], cur_rate_low, cur_rate_high, sum_rate, majump, [rate], bd)
+brackets = JP.get_jump_bracket_fwrappers(ulow, params, t, (crj,))
+p = DummyAggregator([0], [0], cur_rate_low, cur_rate_high, sum_rate, majump,
+    [rate], brackets, bd)
 
 u = [100]
 JP.update_u_brackets!(p, u)
@@ -77,7 +82,8 @@ reaction_index = 2
 @test JP.get_jump_brackets(reaction_index, p, params, t)[1] == rate(p.uhigh, params, t)
 @test JP.get_jump_brackets(reaction_index, p, params, t)[2] == rate(p.ulow, params, t)
 
-p = DummyAggregator([0], [0], cur_rate_low, cur_rate_high, sum_rate, majump, [rate], bd)
+p = DummyAggregator([0], [0], cur_rate_low, cur_rate_high, sum_rate, majump,
+    [rate], brackets, bd)
 JP.set_bracketing!(p, u, params, t)
 @test p.ulow[1]≈u[1] * (1 - fluctuation_rate) atol=1
 @test p.uhigh[1]≈u[1] * (1 + fluctuation_rate) atol=1
@@ -86,3 +92,15 @@ JP.set_bracketing!(p, u, params, t)
 @test p.cur_rate_low[2] == rate(p.uhigh, params, t)
 @test p.cur_rate_high[2] == rate(p.ulow, params, t)
 @test p.sum_rate ≈ sum(p.cur_rate_high)
+
+# non-monotonic rate function
+bounded_crj = ConstantRateJump((u, p, t) -> u[1] / (1 + u[2]), affect!;
+    lrate = (ulow, uhigh, p, t) -> ulow[1] / (1 + uhigh[2]),
+    urate = (ulow, uhigh, p, t) -> uhigh[1] / (1 + ulow[2]))
+
+box_low, box_high = [2, 5], [6, 9]
+box_states = [[a, b] for a in box_low[1]:box_high[1], b in box_low[2]:box_high[2]]
+
+lo = JP.lower_rate_bound(bounded_crj, box_low, box_high, params, t)
+hi = JP.upper_rate_bound(bounded_crj, box_low, box_high, params, t)
+@test all(lo <= bounded_crj.rate(u, params, t) <= hi for u in box_states)

--- a/test/bracketing.jl
+++ b/test/bracketing.jl
@@ -8,7 +8,7 @@ bd = BracketData(fluctuation_rate, threshold, Δu)
 
 ### Getters ###
 species_index = 1
-# The fluctuation rate δ corresponds to species brackets (1-δ)*u, (1+δ)*u. So 0 < δ < 1. 
+# The fluctuation rate δ corresponds to species brackets (1-δ)*u, (1+δ)*u. So 0 < δ < 1.
 @test 0 < JP.getfr(bd, species_index) < 1
 # If u < threshold, then the brackets are (max(u-Δu, 0), u+Δu). So 0 <= threshold and 0 <= Δu.
 @test 0 <= JP.gettv(bd, species_index)
@@ -46,8 +46,9 @@ affect!(integrator) = nothing
 crj = ConstantRateJump(rate, affect!)
 params = nothing
 t = 0.0
-@test JP.cjump_brackets(crj, ulow, uhigh, params, t)[1] == 1 / 10 # low
-@test JP.cjump_brackets(crj, ulow, uhigh, params, t)[2] == 1 / 2 # high
+ucur = [5]
+@test JP.cjump_brackets(crj, ulow, uhigh, ucur, params, t)[1] == 1 / 10 # low
+@test JP.cjump_brackets(crj, ulow, uhigh, ucur, params, t)[2] == 1 / 2 # high
 
 ### Aggregator ###
 mutable struct DummyAggregator{T, M, R, CB, BD} <:
@@ -76,11 +77,11 @@ JP.update_u_brackets!(p, u)
 @test p.uhigh[1]≈u[1] * (1 + fluctuation_rate) atol=1
 
 reaction_index = 1
-@test JP.get_jump_brackets(reaction_index, p, params, t)[1] == majump_rates[1] * p.ulow[1]
-@test JP.get_jump_brackets(reaction_index, p, params, t)[2] == majump_rates[1] * p.uhigh[1]
+@test JP.get_jump_brackets(reaction_index, p, u, params, t)[1] == majump_rates[1] * p.ulow[1]
+@test JP.get_jump_brackets(reaction_index, p, u, params, t)[2] == majump_rates[1] * p.uhigh[1]
 reaction_index = 2
-@test JP.get_jump_brackets(reaction_index, p, params, t)[1] == rate(p.uhigh, params, t)
-@test JP.get_jump_brackets(reaction_index, p, params, t)[2] == rate(p.ulow, params, t)
+@test JP.get_jump_brackets(reaction_index, p, u, params, t)[1] == rate(p.uhigh, params, t)
+@test JP.get_jump_brackets(reaction_index, p, u, params, t)[2] == rate(p.ulow, params, t)
 
 p = DummyAggregator([0], [0], cur_rate_low, cur_rate_high, sum_rate, majump,
     [rate], brackets, bd)
@@ -97,22 +98,22 @@ JP.set_bracketing!(p, u, params, t)
 nonmonotonic_rate(u, p, t) = u[1] / (1 + u[2])
 
 joint_crj = ConstantRateJump(nonmonotonic_rate, affect!;
-    bounds = (ulow, uhigh, p, t) -> RateBounds(lrate = ulow[1] / (1 + uhigh[2]),
+    bounds = (ulow, uhigh, u, p, t) -> RateBounds(lrate = ulow[1] / (1 + uhigh[2]),
                                                urate = uhigh[1] / (1 + ulow[2])))
 
-box_low, box_high = [2, 5], [6, 9]
+box_low, box_high, box_cur = [2, 5], [6, 9], [4, 7]
 box_states = [[a, b] for a in box_low[1]:box_high[1], b in box_low[2]:box_high[2]]
 
-lo, hi = JP.cjump_brackets(joint_crj, box_low, box_high, params, t)
+lo, hi = JP.cjump_brackets(joint_crj, box_low, box_high, box_cur, params, t)
 @test all(lo <= nonmonotonic_rate(u, params, t) <= hi for u in box_states)
 
 # one-sided rate bounds
 split_crj = ConstantRateJump(nonmonotonic_rate, affect!;
-    lrate = (ulow, uhigh, p, t) -> RateBounds(lrate = ulow[1] / (1 + uhigh[2])),
-    urate = (ulow, uhigh, p, t) -> RateBounds(urate = uhigh[1] / (1 + ulow[2])))
+    lrate = (ulow, uhigh, u, p, t) -> RateBounds(lrate = ulow[1] / (1 + uhigh[2])),
+    urate = (ulow, uhigh, u, p, t) -> RateBounds(urate = uhigh[1] / (1 + ulow[2])))
 
-lo = JP.lower_rate_bound(split_crj, box_low, box_high, params, t)
-hi = JP.upper_rate_bound(split_crj, box_low, box_high, params, t)
+lo = JP.lower_rate_bound(split_crj, box_low, box_high, box_cur, params, t)
+hi = JP.upper_rate_bound(split_crj, box_low, box_high, box_cur, params, t)
 @test all(lo <= nonmonotonic_rate(u, params, t) <= hi for u in box_states)
 
 @test_throws ErrorException JP.get_jump_bracket_fwrappers(box_low, params, t,

--- a/test/bracketing.jl
+++ b/test/bracketing.jl
@@ -66,7 +66,7 @@ end
 cur_rate_low = [0.0, 0.0]
 cur_rate_high = [0.0, 0.0]
 sum_rate = 0.0
-brackets = JP.get_jump_bracket_fwrappers(ulow, params, t, (crj,))
+brackets = JP.get_jump_bracket_fwrappers(ulow, params, t, (crj,), RSSA())
 p = DummyAggregator([0], [0], cur_rate_low, cur_rate_high, sum_rate, majump,
     [rate], brackets, bd)
 
@@ -93,14 +93,31 @@ JP.set_bracketing!(p, u, params, t)
 @test p.cur_rate_high[2] == rate(p.ulow, params, t)
 @test p.sum_rate ≈ sum(p.cur_rate_high)
 
-# non-monotonic rate function
-bounded_crj = ConstantRateJump((u, p, t) -> u[1] / (1 + u[2]), affect!;
-    lrate = (ulow, uhigh, p, t) -> ulow[1] / (1 + uhigh[2]),
-    urate = (ulow, uhigh, p, t) -> uhigh[1] / (1 + ulow[2]))
+### user supplied rate bounds ###
+nonmonotonic_rate(u, p, t) = u[1] / (1 + u[2])
+
+joint_crj = ConstantRateJump(nonmonotonic_rate, affect!;
+    bounds = (ulow, uhigh, p, t) -> RateBounds(lrate = ulow[1] / (1 + uhigh[2]),
+                                               urate = uhigh[1] / (1 + ulow[2])))
 
 box_low, box_high = [2, 5], [6, 9]
 box_states = [[a, b] for a in box_low[1]:box_high[1], b in box_low[2]:box_high[2]]
 
-lo = JP.lower_rate_bound(bounded_crj, box_low, box_high, params, t)
-hi = JP.upper_rate_bound(bounded_crj, box_low, box_high, params, t)
-@test all(lo <= bounded_crj.rate(u, params, t) <= hi for u in box_states)
+lo, hi = JP.cjump_brackets(joint_crj, box_low, box_high, params, t)
+@test all(lo <= nonmonotonic_rate(u, params, t) <= hi for u in box_states)
+
+# one-sided rate bounds
+split_crj = ConstantRateJump(nonmonotonic_rate, affect!;
+    lrate = (ulow, uhigh, p, t) -> RateBounds(lrate = ulow[1] / (1 + uhigh[2])),
+    urate = (ulow, uhigh, p, t) -> RateBounds(urate = uhigh[1] / (1 + ulow[2])))
+
+lo = JP.lower_rate_bound(split_crj, box_low, box_high, params, t)
+hi = JP.upper_rate_bound(split_crj, box_low, box_high, params, t)
+@test all(lo <= nonmonotonic_rate(u, params, t) <= hi for u in box_states)
+
+@test_throws ErrorException JP.get_jump_bracket_fwrappers(box_low, params, t,
+    (split_crj,), RSSA())
+@test_throws ErrorException JP.get_jump_lrate_fwrappers(box_low, params, t,
+    (joint_crj,), RSSA())
+@test_throws ErrorException JP.get_jump_urate_fwrappers(box_low, params, t,
+    (joint_crj,), RSSA())


### PR DESCRIPTION
## Summary

Added `lrate(ulow, uhigh, p, t)` and `urate(ulow, uhigh, p, t)` to `ConstantRateJump`, allowing users to specify bounds on the rate with respect to state for the interval `[ulow,uhigh]`, which is used for bracketing aggregators `RSSA` and `RSSACR`.

This addresses #620. Previously, `get_cjump_brackets` resolved these bounds by evaluating the rate at the corners `ulow`, `uhigh` and optionally reordering the result. This is only valid when the rate is monotonic in the same direction in every species. Exposing `lrate` and `urate` means bracketing aggregators can now use crj's with arbitrary rate functions as long as the user specified bounds are correct. Behaviour remains unchanged if bounds are not supplied (but I think we should only preserve the fallback bound calculation for increasing rate functions and remove the reordering flow).

It turns out that this potential correctness issue is actually hit in this repository: `test/allocations.jl` uses `u = [1000, 10]` and `r1 = (η/K)(K - u[1] - u[2]) * u[1]`, which increases in `u[1]` but decreases in `u[2]` locally around `u`. The default fallback bounds are `(818.46, 977.46)`, whereas the rate actually ranges over `(817.74, 978.34)`. It's a small effect here but it can get much more severe at low copy numbers (e.g. for `u[1]/(1+u[2])` at `u=[5,1]`, the automatic bounds are `(1.0, 1.5)` vs the real ones `(0.17, 9.0)`). I didn't touch the test because it measures allocation rather than correctness, but ideally we would specify rate bounds for this example.

## Checklist

- [X] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [X] All documentation related to code changes were updated
- [X] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [X] Any new documentation only uses public API
  
## Notes

`ConstantRateJump` gained two type parameters, so the two-parameter form no longer matches, which is technically breaking public API. However, nothing seems to use the type annotation in any downstream dependencies.

The bracketing requirement is now documented for the `RSSA` and `RSSACR` aggregators.

All tests passed locally.