### PR TITLE
Release JumpProcesses 9.32.2

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "JumpProcesses"
 uuid = "ccbc3e58-028d-4f4c-8cd5-9ae44345cda5"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "9.32.1"
+version = "9.32.2"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"


### PR DESCRIPTION
Bumps `JumpProcesses` 9.32.1 -> 9.32.2 (patch).

Source files changed since 9.32.1:
- `src/simple_regular_solve.jl`

Commits:
- Report successful completion from CPU tau-leaping solvers (#651)

Version bump only; no code changes in this PR.


🤖 Generated with [Claude Code](https://claude.com/claude-code) (model: claude-opus-5[1m])

https://claude.ai/code/session_014FEzNTLFutCmTEAZ3zBg5R
