### PR TITLE
Fix ExtendedJumpArray eltype assertion on 32-bit Julia

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -33,6 +33,9 @@ JumpProcessesForwardDiffExt = "ForwardDiff"
 JumpProcessesKernelAbstractionsExt = ["Adapt", "KernelAbstractions"]
 JumpProcessesOrdinaryDiffEqCoreExt = "OrdinaryDiffEqCore"
 
+[sources]
+DiffEqBase = {url = "https://github.com/ChrisRackauckas-Claude/OrdinaryDiffEq.jl.git", rev = "fix-32bit-interp-points-range", subdir = "lib/DiffEqBase"}
+
 [compat]
 ADTypes = "1.22.0"
 Adapt = "4.6.0"

--- a/Project.toml
+++ b/Project.toml
@@ -33,9 +33,6 @@ JumpProcessesForwardDiffExt = "ForwardDiff"
 JumpProcessesKernelAbstractionsExt = ["Adapt", "KernelAbstractions"]
 JumpProcessesOrdinaryDiffEqCoreExt = "OrdinaryDiffEqCore"
 
-[sources]
-DiffEqBase = {url = "https://github.com/ChrisRackauckas-Claude/OrdinaryDiffEq.jl.git", rev = "fix-32bit-interp-points-range", subdir = "lib/DiffEqBase"}
-
 [compat]
 ADTypes = "1.22.0"
 Adapt = "4.6.0"

--- a/src/aggregators/ccnrm.jl
+++ b/src/aggregators/ccnrm.jl
@@ -52,7 +52,7 @@ function CCNRMJumpAggregation(nj::Int, njt::T, et::T, crs::Vector{T}, sr::T,
         rng, dg, ptt)
 end
 
-+############################# Required Functions ##############################
+############################# Required Functions ##############################
 # creating the JumpAggregation structure (function wrapper-based constant jumps)
 function aggregate(aggregator::CCNRM, u, p, t, end_time, constant_jumps,
         ma_jumps, save_positions, rng; kwargs...)

--- a/src/aggregators/prioritytable.jl
+++ b/src/aggregators/prioritytable.jl
@@ -350,13 +350,14 @@ end
 function PriorityTimeTable(
         times::AbstractVector, mintime, timestep; binwidthconst = 16, numbinsconst = 20)
     binwidth = binwidthconst * timestep
-    numbins = floor(Int64, numbinsconst * sqrt(length(times)))
+    # Use native Int so F matches Tuple{Int,Int} / Int kwargs on 32-bit.
+    numbins = floor(Int, numbinsconst * sqrt(length(times)))
     maxtime = mintime + numbins * binwidth
 
     pidtype = typeof(numbins)
     ptype = eltype(times)
     groups = Vector{PriorityGroup{ptype, Vector{pidtype}}}()
-    pidtogroup = Vector{Tuple{Int, Int}}(undef, length(times))
+    pidtogroup = Vector{Tuple{pidtype, pidtype}}(undef, length(times))
 
     ttgdata = TimeGrouper{ptype}(mintime, binwidth)
     # Create the groups, [t_min, t_min + τ), [t_min + τ, t_min + 2τ)...
@@ -366,7 +367,7 @@ function PriorityTimeTable(
 
     ptt = PriorityTimeTable(
         groups, pidtogroup, times, ttgdata, zero(pidtype),
-        zero(pidtype), maxtime, binwidthconst, numbinsconst)
+        zero(pidtype), maxtime, pidtype(binwidthconst), pidtype(numbinsconst))
     # Insert priority ids into the groups
     for (pid, time) in enumerate(times)
         if time > maxtime

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -69,7 +69,8 @@ end
 # jump aggregator's RNG. We cannot assume the JumpProblem's stored RNG is any particular
 # type, so we pass the seed through `hash` (to decorrelate from the input) and then through
 # a Xoshiro draw (to ensure strong mixing regardless of the target RNG's seeding quality).
-const _JUMP_SEED_SALT = 0x4a756d7050726f63  # "JumPProc" in ASCII
+# Truncate salt to native UInt so hash(::UInt64, ::UInt) matches on 32-bit Julia.
+const _JUMP_SEED_SALT = 0x4a756d7050726f63 % UInt  # "JumPProc" in ASCII
 _derive_jump_seed(seed) = rand(Random.Xoshiro(hash(seed, _JUMP_SEED_SALT)), UInt64)
 
 function resetted_jump_problem(_jump_prob, seed)

--- a/test/extended_jump_array.jl
+++ b/test/extended_jump_array.jl
@@ -63,10 +63,10 @@ bc_mismatch = ExtendedJumpArray(rand(rng, 8), rand(rng, 4))
 bc_dtype_1 = ExtendedJumpArray(rand(rng, 10), rand(rng, 1:10, 2))
 bc_dtype_2 = ExtendedJumpArray(rand(rng, 10), rand(rng, 1:10, 2))
 result = bc_dtype_1 + bc_dtype_2 * 2
-@test eltype(result.jump_u) == Int64
+@test eltype(result.jump_u) == Int
 out_result = ExtendedJumpArray(zeros(10), zeros(2))
 out_result .= bc_dtype_1 .+ bc_dtype_2 .* 2
-@test eltype(result.jump_u) == Int64
+@test eltype(result.jump_u) == Int
 @test out_result ≈ result
 
 # Test that fast broadcasting also gives the correct results


### PR DESCRIPTION
## Summary
- x86 InterfaceI fails `eltype(result.jump_u) == Int64` (actual `Int32`)
- Assert against native `Int`

## Test plan
- [ ] InterfaceI x86 green
- [ ] Existing InterfaceI x64 green


Made with [Cursor](https://cursor.com)