### PR TITLE
Release JumpProcesses 9.32.3

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "JumpProcesses"
 uuid = "ccbc3e58-028d-4f4c-8cd5-9ae44345cda5"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "9.32.2"
+version = "9.32.3"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"


### PR DESCRIPTION
Bumps `JumpProcesses` 9.32.2 -> 9.32.3 (patch).

Source files changed since 9.32.2:
- `src/aggregators/ccnrm.jl`
- `src/aggregators/prioritytable.jl`
- `src/solve.jl`

Commits:
- Add 32-bit InterfaceI CI lane via test_groups.toml (#656)
- Fix ExtendedJumpArray eltype assertion on 32-bit Julia (#657)

Version bump only; no code changes in this PR.


🤖 Generated with [Claude Code](https://claude.com/claude-code) (model: claude-opus-5[1m])

https://claude.ai/code/session_014FEzNTLFutCmTEAZ3zBg5R
