### PR TITLE
Fix ExtendedJumpArray subset getindex on Julia 1.13

### DIFF
--- a/src/extended_jump_array.jl
+++ b/src/extended_jump_array.jl
@@ -113,10 +113,15 @@ LinearAlgebra.mul!(c::ExtendedJumpArray, A::AbstractVecOrMat, u::AbstractVector)
 LinearAlgebra.mul!(c::ExtendedJumpArray, A::LinearAlgebra.AbstractTriangular,
     u::AbstractVector) = _mul_extended_jump_array!(c, A, u)
 
-# Ignore axes
+# Whole-array copies stay ExtendedJumpArrays. A subset getindex asks `similar`
+# for a container of the index shape, which no longer matches this array's axes;
+# Julia 1.13 checks the result's axes, so return a plain dense array there.
 function Base.similar(A::ExtendedJumpArray, ::Type{S},
         axes::Tuple{Base.OneTo{Int}}) where {S}
-    ExtendedJumpArray(similar(A.u, S), similar(A.jump_u, S))
+    if axes == Base.axes(A)
+        return ExtendedJumpArray(similar(A.u, S), similar(A.jump_u, S))
+    end
+    return similar(A.u, S, axes)
 end
 
 # plotting

--- a/test/extended_jump_array.jl
+++ b/test/extended_jump_array.jl
@@ -215,3 +215,16 @@ let
     sol = solve(jprob, Rodas5P(linsolve = QRFactorization()))
     @test sol.retcode == ReturnCode.Success
 end
+
+# Subset getindex on an ExtendedJumpArray must return a dense array of the
+# index shape: Julia 1.13's `_unsafe_getindex` verifies `axes(similar(...))`
+# against the index shape, which the axes-ignoring `similar` violated.
+let
+    u = ExtendedJumpArray([1.0, 2.0, 3.0], [4.0])
+    @test u[[1, 2, 3]] isa Vector{Float64}
+    @test u[[1, 2, 3]] == [1.0, 2.0, 3.0]
+    @test u[[4]] == [4.0]
+    @test Vector(u[:]) == [1.0, 2.0, 3.0, 4.0]
+    @test similar(u) isa ExtendedJumpArray
+    @test copy(u) isa ExtendedJumpArray
+end


### PR DESCRIPTION
## Summary

Documentation CI on Julia 1.13 fails running `@example` blocks (`discrete_stochastic_example.md`, `jump_diffusion.md`, `simple_poisson_process.md`):

```
DimensionMismatch: output array is the wrong size; expected (Base.OneTo(4),), got (5,)
  throw_checksize_error(::ExtendedJumpArray, ::Tuple{Base.OneTo{Int64}}) @ multidimensional.jl:1030
  _unsafe_getindex ... ode_interpolant(...) @ OrdinaryDiffEqCore generic_dense.jl:1427
```

Root cause: `ExtendedJumpArray`'s `similar(A, S, axes)` ignored the requested axes and always returned a same-shaped `ExtendedJumpArray`. Julia 1.13's `_unsafe_getindex` (used by `getindex(A, idxs::AbstractVector)` and by the `idxs` path in ODE dense interpolation, e.g. `y₀[idxs]` when plotting/interpolating solutions) now allocates `similar(A, eltype, index_shape)` and verifies `axes(out) == index_shape`. For a subset index like `u[[1,2,3]]` on a length-4 EJA the ignored-axes `similar` returned a length-4 array, tripping the check.

Fix: return an `ExtendedJumpArray` only when the requested axes equal `axes(A)` (the case the 2018-era method exists for); otherwise return a plain dense array via `similar(A.u, S, axes)`, which is what subset getindex needs anyway.

## Test plan

- [x] New regression assertions: `u[[1,2,3]]` returns `Vector{Float64}`, `u[[4]]` (indexing into `jump_u`) works, `similar`/`copy` still return `ExtendedJumpArray`
- [x] Assertions fail on unfixed code (DimensionMismatch) on Julia 1.13.0, pass with the fix on 1.13.0 and 1.12.7
- [x] `u[:]` content asserted (type differs across Julia versions: dims-based path returns `Vector` on ≤1.12, axes-based returns EJA on 1.13)

🤖 Generated with [Devin](https://devin.ai) — Agent-Harness: Devin CLI 3000.10.21, Agent-Model: SWE-2 Max, Agent-Session: /home/crackauc/.local/share/devin/cli/summaries/history_4c9fddb81d834736.md (local session transcript; no shareable URL)